### PR TITLE
Reactive connection status

### DIFF
--- a/packages/frontend/src/contexts/HassContext.tsx
+++ b/packages/frontend/src/contexts/HassContext.tsx
@@ -292,7 +292,9 @@ export const HassProvider: FC<
       // Note: states/services/devices accessed via refs so hass object doesn't recreate on updates
       return {
         auth: null as unknown as HomeAssistant['auth'],
-        connected: wsConnection.connected,
+        get connected() {
+          return wsConnection.connected;
+        },
         config: {} as unknown as HomeAssistant['config'],
         themes: { darkMode: false },
         panels: {},


### PR DESCRIPTION
Hi @FezVrasta 

I reported last week (see issue https://github.com/FezVrasta/cafe-hass/issues/145) that my standalone CAFE instance always showed a green *"Connected"* status in the toolbar, even if CAFE wasn't connected to my Home Assistant instance.

Seemed the connection status was only set once, when the hass object was created.  This PR makes it *reactive*, so it is updated every time the connection status changes.

+ When there is a connection:

   <img width="245" height="45" alt="image" src="https://github.com/user-attachments/assets/350f14c2-37b1-4134-94cd-d8f61e618b14" />

   That is now correctly visualized in the header:

   <img width="350" height="45" alt="image" src="https://github.com/user-attachments/assets/73be3e52-e904-4c1d-85f1-8dfb70a591b0" />

+ When there is ***no*** connection:

   <img width="380" height="54" alt="image" src="https://github.com/user-attachments/assets/200b089f-4b94-4663-8e58-b1b2740921be" />

   This is now also correctly visualized in the header:
   
   <img width="400" height="38" alt="image" src="https://github.com/user-attachments/assets/a3110e45-6c67-4022-aa9f-21a36290d09d" />

Kind regards,

Bart