### PR TITLE
IndexedDB fallback

### DIFF
--- a/packages/frontend/src/utils/indexeddb-storage.ts
+++ b/packages/frontend/src/utils/indexeddb-storage.ts
@@ -130,6 +130,24 @@ export class IndexedDBStorage implements StateStorage<Promise<void>> {
     setItem: (name: string, value: StorageValue<S>) => Promise<void>;
     removeItem: (name: string) => Promise<void>;
   } {
+    // In Node (test) environments IndexedDB is not available. Fall back to an
+    // in-memory Map implementation to allow tests to run without a browser.
+    if (!('indexedDB' in globalThis)) {
+      const mem = new Map<string, string>();
+      return {
+        getItem: async (name: string) => {
+          const v = mem.get(name) ?? null;
+          return v ? (JSON.parse(v) as StorageValue<S>) : null;
+        },
+        setItem: async (name: string, value: StorageValue<S>) => {
+          mem.set(name, JSON.stringify(value));
+        },
+        removeItem: async (name: string) => {
+          mem.delete(name);
+        },
+      };
+    }
+
     const storage = new IndexedDBStorage(dbName, storeName);
 
     return {


### PR DESCRIPTION
Hi @FezVrasta 

When running ***yarn test*** I always got a lot of errors (via VS Code):

<img width="343" height="108" alt="image" src="https://github.com/user-attachments/assets/e7cbbf2d-1dcc-4ef2-b372-f17682af6378" />

It was all the time the same error ***"indexedDB is not defined"***:

<img width="649" height="462" alt="image" src="https://github.com/user-attachments/assets/a11bcc7a-3741-4c9b-8a19-8ece8baf163f" />

Claude adviced to use an in-memory Map-backed adapter, when indexedDB is unavailable. 
It seems to do the job, because now all the errors are gone.

Kind regards,
Bart