### PR TITLE
Execute Parallel non-Action nodes + fix for ghost node as result of parallel nodes being incorreclty imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "build:ha": "npm run build && echo '✓ Built and copied to custom_components/cafe/www/'",
+    "build:ha": "turbo run build --force && echo '✓ Built and copied to custom_components/cafe/www/'",
     "test": "vitest",
     "test:cli": "yarn workspace @cafe/transpiler cli",
     "lint": "turbo run lint",

--- a/packages/transpiler/src/__tests__/parallel-trigger-branches.test.ts
+++ b/packages/transpiler/src/__tests__/parallel-trigger-branches.test.ts
@@ -195,6 +195,125 @@ describe('Parallel Trigger Branches', () => {
     expect(result.yaml).toContain('action_A');
   });
 
+  it('should parse legacy system_log.write parallel blocks without phantom nodes', async () => {
+      // YAML produced by an older transpiler version where non-action parallel
+      // targets were emitted as system_log.write placeholders instead of
+      // parallel_branch: aliases.
+      const legacyYaml = `
+alias: Legacy Parallel
+description: ""
+triggers:
+  - trigger: time
+    at: "09:00:00"
+  - trigger: time
+    at: "21:00:00"
+conditions: []
+actions:
+  - variables:
+      current_node: >-
+        {% if trigger.idx == "0" %}__parallel_trigger_0{% elif trigger.idx == "1" %}action_C{% else %}END{% endif %}
+      flow_context: {}
+  - repeat:
+      until:
+        - condition: template
+          value_template: "{{ current_node == \\"END\\" }}"
+      sequence:
+        - choose:
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"__parallel_trigger_0\\" }}"
+              sequence:
+                - parallel:
+                    - data:
+                        message: "Node: condition_X"
+                      action: system_log.write
+                    - data:
+                        message: "Node: condition_Y"
+                      action: system_log.write
+                - variables:
+                    current_node: END
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"condition_X\\" }}"
+              sequence:
+                - variables:
+                    current_node: >-
+                      {% if is_state('binary_sensor.door', 'on') %}action_A{% else %}END{% endif %}
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"condition_Y\\" }}"
+              sequence:
+                - variables:
+                    current_node: >-
+                      {% if is_state('binary_sensor.window', 'on') %}action_B{% else %}END{% endif %}
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"action_A\\" }}"
+              sequence:
+                - alias: Door Light
+                  action: light.turn_on
+                - variables:
+                    current_node: END
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"action_B\\" }}"
+              sequence:
+                - alias: Window Fan
+                  action: switch.turn_on
+                - variables:
+                    current_node: END
+            - conditions:
+                - condition: template
+                  value_template: "{{ current_node == \\"action_C\\" }}"
+              sequence:
+                - alias: Lights Off
+                  action: light.turn_off
+                - variables:
+                    current_node: END
+mode: single
+variables:
+  _cafe_metadata:
+    version: 1
+    strategy: native
+    nodes:
+      trigger_0: { x: 0, "y": 0 }
+      trigger_1: { x: 0, "y": 300 }
+      condition_X: { x: 300, "y": -100 }
+      condition_Y: { x: 300, "y": 100 }
+      action_A: { x: 600, "y": -100 }
+      action_B: { x: 600, "y": 100 }
+      action_C: { x: 300, "y": 300 }
+`;
+
+      const parser = new YamlParser();
+      const result = await parser.parse(legacyYaml);
+
+      expect(result.success).toBe(true);
+      expect(result.graph).toBeDefined();
+
+      const parsed = result.graph!;
+
+      // No phantom __parallel_trigger_* nodes
+      const phantomNodes = parsed.nodes.filter((n) => n.id.startsWith('__parallel_trigger_'));
+      expect(phantomNodes).toHaveLength(0);
+
+      // Find triggers by type
+      const triggerNodes = parsed.nodes.filter(isTriggerNode);
+      expect(triggerNodes).toHaveLength(2);
+
+      // The first trigger (09:00) should have edges to both condition_X and condition_Y
+      const trigger0 = triggerNodes[0];
+      const trigger0Edges = parsed.edges.filter((e) => e.source === trigger0.id);
+      expect(trigger0Edges).toHaveLength(2);
+      expect(trigger0Edges.map((e) => e.target).sort()).toEqual(['condition_X', 'condition_Y']);
+
+      // The second trigger (21:00) should have an edge to action_C
+      const trigger1 = triggerNodes[1];
+      const trigger1Edges = parsed.edges.filter((e) => e.source === trigger1.id);
+      expect(trigger1Edges).toHaveLength(1);
+      expect(trigger1Edges[0].target).toBe('action_C');
+    });
+
   describe('round-trip (transpile → parse)', () => {
     it('should not create phantom nodes for __parallel_trigger_* entries', async () => {
       const flow: FlowGraph = {

--- a/packages/transpiler/src/__tests__/parallel-trigger-branches.test.ts
+++ b/packages/transpiler/src/__tests__/parallel-trigger-branches.test.ts
@@ -1,6 +1,8 @@
 import type { FlowGraph } from '@cafe/shared';
+import { isActionNode, isTriggerNode } from '@cafe/shared';
 import { describe, expect, it } from 'vitest';
 import { FlowTranspiler } from '../FlowTranspiler';
+import { YamlParser } from '../parser/YamlParser';
 
 describe('Parallel Trigger Branches', () => {
   it('should execute all actions when a trigger has multiple targets', async () => {
@@ -191,5 +193,206 @@ describe('Parallel Trigger Branches', () => {
 
     // Should directly route to action_A
     expect(result.yaml).toContain('action_A');
+  });
+
+  describe('round-trip (transpile → parse)', () => {
+    it('should not create phantom nodes for __parallel_trigger_* entries', async () => {
+      const flow: FlowGraph = {
+        id: 'dd446194-a857-41cd-a2c6-7e44df19919e',
+        name: 'Parallel Trigger Round Trip',
+        nodes: [
+          {
+            id: 'trigger_0',
+            type: 'trigger',
+            position: { x: -60, y: 45 },
+            data: {
+              entity_id: ['update.home_assistant_core_update'],
+              trigger: 'state',
+            },
+          },
+          {
+            id: 'action_A',
+            type: 'action',
+            position: { x: 360, y: -15 },
+            data: {
+              service: 'light.turn_on',
+              alias: 'Light Turn On',
+            },
+          },
+          {
+            id: 'action_B',
+            type: 'action',
+            position: { x: 360, y: 155 },
+            data: {
+              service: 'switch.turn_on',
+              alias: 'Switch Turn On',
+            },
+          },
+          {
+            id: 'trigger_1',
+            type: 'trigger',
+            position: { x: -30, y: 360 },
+            data: {
+              trigger: 'time',
+              at: '08:00:00',
+            },
+          },
+          {
+            id: 'action_C',
+            type: 'action',
+            position: { x: 345, y: 360 },
+            data: {
+              service: 'light.turn_off',
+              alias: 'Light Turn Off',
+            },
+          },
+        ],
+        edges: [
+          { id: 'e1', source: 'trigger_0', target: 'action_A' },
+          { id: 'e2', source: 'trigger_0', target: 'action_B' },
+          { id: 'e3', source: 'trigger_1', target: 'action_C' },
+        ],
+        metadata: { mode: 'single', initial_state: true },
+        version: 1,
+      };
+
+      // Transpile flow → YAML
+      const transpiler = new FlowTranspiler();
+      const transpileResult = transpiler.transpile(flow);
+      expect(transpileResult.success).toBe(true);
+      expect(transpileResult.yaml).toContain('__parallel_trigger_0');
+
+      // Parse YAML → flow
+      const parser = new YamlParser();
+      const parseResult = await parser.parse(transpileResult.yaml!);
+      expect(parseResult.success).toBe(true);
+      expect(parseResult.graph).toBeDefined();
+
+      const parsed = parseResult.graph!;
+
+      // No phantom __parallel_trigger_* nodes should exist
+      const phantomNodes = parsed.nodes.filter((n) => n.id.startsWith('__parallel_trigger_'));
+      expect(phantomNodes).toHaveLength(0);
+
+      // Find nodes by type using type guards
+      const triggerNodes = parsed.nodes.filter(isTriggerNode);
+      const actionNodes = parsed.nodes.filter(isActionNode);
+
+      // trigger_0 (state) should have edges to both action_A and action_B
+      const trigger0 = triggerNodes.find((n) => n.data.trigger === 'state');
+      expect(trigger0).toBeDefined();
+      const trigger0Edges = parsed.edges.filter((e) => e.source === trigger0!.id);
+      const trigger0Targets = trigger0Edges.map((e) => e.target).sort();
+      const actionAId = actionNodes.find((n) => n.data.service === 'light.turn_on')?.id;
+      const actionBId = actionNodes.find((n) => n.data.service === 'switch.turn_on')?.id;
+      expect(trigger0Targets).toEqual([actionAId, actionBId].sort());
+
+      // trigger_1 (time) should have an edge to action_C
+      const trigger1 = triggerNodes.find((n) => n.data.trigger === 'time');
+      expect(trigger1).toBeDefined();
+      const trigger1Edges = parsed.edges.filter((e) => e.source === trigger1!.id);
+      const actionCId = actionNodes.find((n) => n.data.service === 'light.turn_off')?.id;
+      expect(trigger1Edges).toHaveLength(1);
+      expect(trigger1Edges[0].target).toBe(actionCId);
+    });
+
+    it('should round-trip trigger fan-out to non-action nodes', async () => {
+      // trigger_0 → condition_X (true→action_A) AND condition_Y (true→action_B)
+      // trigger_1 → action_D
+      const flow: FlowGraph = {
+        id: 'cc112233-4455-6677-8899-aabbccddeeff',
+        name: 'Parallel Trigger Non-Action',
+        nodes: [
+          {
+            id: 'trigger_0',
+            type: 'trigger',
+            position: { x: 0, y: 0 },
+            data: { trigger: 'time', at: '09:00:00' },
+          },
+          {
+            id: 'condition_X',
+            type: 'condition',
+            position: { x: 300, y: -100 },
+            data: {
+              condition: 'state',
+              entity_id: 'binary_sensor.door',
+              state: 'on',
+            },
+          },
+          {
+            id: 'action_A',
+            type: 'action',
+            position: { x: 600, y: -100 },
+            data: { service: 'light.turn_on', alias: 'Door Light' },
+          },
+          {
+            id: 'condition_Y',
+            type: 'condition',
+            position: { x: 300, y: 100 },
+            data: {
+              condition: 'state',
+              entity_id: 'binary_sensor.window',
+              state: 'on',
+            },
+          },
+          {
+            id: 'action_B',
+            type: 'action',
+            position: { x: 600, y: 100 },
+            data: { service: 'switch.turn_on', alias: 'Window Fan' },
+          },
+          {
+            id: 'trigger_1',
+            type: 'trigger',
+            position: { x: 0, y: 300 },
+            data: { trigger: 'time', at: '21:00:00' },
+          },
+          {
+            id: 'action_D',
+            type: 'action',
+            position: { x: 300, y: 300 },
+            data: { service: 'light.turn_off', alias: 'Lights Off' },
+          },
+        ],
+        edges: [
+          { id: 'e1', source: 'trigger_0', target: 'condition_X' },
+          { id: 'e2', source: 'trigger_0', target: 'condition_Y' },
+          { id: 'e3', source: 'condition_X', target: 'action_A', sourceHandle: 'true' },
+          { id: 'e4', source: 'condition_Y', target: 'action_B', sourceHandle: 'true' },
+          { id: 'e5', source: 'trigger_1', target: 'action_D' },
+        ],
+        metadata: { mode: 'single', initial_state: true },
+        version: 1,
+      };
+
+      const transpiler = new FlowTranspiler();
+      const transpileResult = transpiler.transpile(flow);
+      expect(transpileResult.success).toBe(true);
+
+      const parser = new YamlParser();
+      const parseResult = await parser.parse(transpileResult.yaml!);
+      expect(parseResult.success).toBe(true);
+      expect(parseResult.graph).toBeDefined();
+
+      const parsed = parseResult.graph!;
+
+      // No phantom nodes
+      const phantomNodes = parsed.nodes.filter((n) => n.id.startsWith('__parallel_trigger_'));
+      expect(phantomNodes).toHaveLength(0);
+
+      // trigger_0 connects to both conditions
+      const triggerNodes = parsed.nodes.filter(isTriggerNode);
+      const trigger0 = triggerNodes.find((n) => n.data.at === '09:00:00');
+      expect(trigger0).toBeDefined();
+      const trigger0Edges = parsed.edges.filter((e) => e.source === trigger0!.id);
+      expect(trigger0Edges).toHaveLength(2);
+
+      const conditionIds = parsed.nodes
+        .filter((n) => n.type === 'condition')
+        .map((n) => n.id)
+        .sort();
+      const trigger0Targets = trigger0Edges.map((e) => e.target).sort();
+      expect(trigger0Targets).toEqual(conditionIds);
+    });
   });
 });

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -954,14 +954,45 @@ export class YamlParser {
     const nodes: FlowNode[] = [];
     const edges: FlowEdge[] = [];
     const conditionNodeIds = new Set<string>();
-    let nodeIdIndex = 0;
+
+    // Group metadata IDs by node type for type-aware assignment.
+    // Without type-aware grouping, depth-first parsing of parallel branches
+    // would assign IDs in the wrong order (e.g., an action gets a condition's ID).
+    const knownNodeTypes = ['set_variables', 'trigger', 'condition', 'action', 'delay', 'wait'];
+    const metadataIdsByType = new Map<string, string[]>();
+    const usedMetadataIds = new Set<string>();
+    for (const id of metadataNodeIds) {
+      const matchedType = knownNodeTypes.find((t) => id.startsWith(`${t}_`));
+      if (matchedType) {
+        if (!metadataIdsByType.has(matchedType)) metadataIdsByType.set(matchedType, []);
+        metadataIdsByType.get(matchedType)!.push(id);
+      }
+    }
+    const metadataTypeIndexes = new Map<string, number>();
+    let sequentialFallbackIndex = 0;
+    let nodeIdCounter = metadataNodeIds.length;
 
     // Helper to get next node ID (from metadata if available, otherwise generate)
     const getNextNodeId = (type: string): string => {
-      if (nodeIdIndex < metadataNodeIds.length) {
-        return metadataNodeIds[nodeIdIndex++];
+      // First: try type-matched metadata ID
+      const ids = metadataIdsByType.get(type);
+      const idx = metadataTypeIndexes.get(type) ?? 0;
+      if (ids && idx < ids.length) {
+        const id = ids[idx];
+        metadataTypeIndexes.set(type, idx + 1);
+        usedMetadataIds.add(id);
+        return id;
       }
-      return generateNodeId(type, nodeIdIndex++);
+      // Second: fallback to next unused metadata ID (handles non-standard ID formats)
+      while (sequentialFallbackIndex < metadataNodeIds.length) {
+        const id = metadataNodeIds[sequentialFallbackIndex++];
+        if (!usedMetadataIds.has(id)) {
+          usedMetadataIds.add(id);
+          return id;
+        }
+      }
+      // Third: generate a new ID
+      return generateNodeId(type, nodeIdCounter++);
     };
 
     // Parse triggers (support both 'trigger' and 'triggers')

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -575,7 +575,7 @@ export class YamlParser {
     for (const [nodeId, info] of nodeInfoMap) {
       if (!/^__parallel_trigger_\d+$/.test(nodeId)) continue;
 
-      const targetIds = this.extractParallelTargetIds(info.parallelItems, nodeInfoMap);
+      const targetIds = this.extractParallelTargetIds(info.parallelItems);
       if (targetIds.length > 0) {
         parallelTriggerTargets.set(nodeId, targetIds);
       }
@@ -746,50 +746,23 @@ export class YamlParser {
 
   /**
    * Extract target node IDs from a synthetic __parallel_trigger_* block's parallel items.
-   * Non-action nodes use system_log.write with "Node: <id>" messages.
-   * Action nodes are matched against nodeInfoMap by comparing action properties.
+   * Each parallel branch is tagged with an alias of the form "parallel_branch:<nodeId>"
+   * by the transpiler, making identification straightforward.
    */
-  private extractParallelTargetIds(
-    parallelItems: unknown[] | undefined,
-    nodeInfoMap: Map<string, { nodeType: string; data: Record<string, unknown> }>
-  ): string[] {
+  private extractParallelTargetIds(parallelItems: unknown[] | undefined): string[] {
     if (!parallelItems) return [];
 
     const targetIds: string[] = [];
-    const matchedNodeIds = new Set<string>();
 
     for (const item of parallelItems) {
       const pItem = item as Record<string, unknown>;
-      const service = (pItem.service || pItem.action) as string | undefined;
+      const alias = pItem.alias as string | undefined;
 
-      // Non-action nodes: { service: 'system_log.write', data: { message: 'Node: <id>' } }
-      if (service === 'system_log.write') {
-        const data = pItem.data as Record<string, unknown> | undefined;
-        const message = data?.message as string | undefined;
-        if (message) {
-          const nodeMatch = message.match(/^Node:\s*(.+)$/);
-          if (nodeMatch) {
-            targetIds.push(nodeMatch[1]);
-            continue;
-          }
-        }
-      }
-
-      // Action nodes: match by comparing action properties against nodeInfoMap
-      if (service) {
-        for (const [candidateId, info] of nodeInfoMap) {
-          if (matchedNodeIds.has(candidateId)) continue;
-          if (info.nodeType !== 'action') continue;
-
-          const cService = info.data.service as string | undefined;
-          if (service !== cService) continue;
-          if (pItem.alias !== info.data.alias) continue;
-          if (JSON.stringify(pItem.target) !== JSON.stringify(info.data.target)) continue;
-          if (JSON.stringify(pItem.data) !== JSON.stringify(info.data.data)) continue;
-
-          targetIds.push(candidateId);
-          matchedNodeIds.add(candidateId);
-          break;
+      // Each branch is tagged: { alias: "parallel_branch:<nodeId>", ... }
+      if (alias) {
+        const branchMatch = alias.match(/^parallel_branch:(.+)$/);
+        if (branchMatch) {
+          targetIds.push(branchMatch[1]);
         }
       }
     }

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -529,6 +529,7 @@ export class YamlParser {
         data: Record<string, unknown>;
         trueTarget: string | null;
         falseTarget: string | null;
+        parallelItems?: unknown[];
       }
     >();
 
@@ -565,6 +566,20 @@ export class YamlParser {
           }
         }
       }
+    }
+
+    // Resolve __parallel_trigger_* synthetic entries.
+    // The transpiler generates these for triggers with multiple targets.
+    // Expand them back into direct trigger→target edges instead of phantom nodes.
+    const parallelTriggerTargets = new Map<string, string[]>();
+    for (const [nodeId, info] of nodeInfoMap) {
+      if (!/^__parallel_trigger_\d+$/.test(nodeId)) continue;
+
+      const targetIds = this.extractParallelTargetIds(info.parallelItems, nodeInfoMap);
+      if (targetIds.length > 0) {
+        parallelTriggerTargets.set(nodeId, targetIds);
+      }
+      nodeInfoMap.delete(nodeId);
     }
 
     // In state-machine strategy, action/condition/delay/wait node IDs are extracted
@@ -648,7 +663,15 @@ export class YamlParser {
         for (let i = 0; i < triggerNodes.length; i++) {
           const targetNodeId = triggerRouting.get(i);
           if (targetNodeId) {
-            edges.push(this.createEdge(triggerNodes[i].id, targetNodeId));
+            // Expand synthetic parallel trigger entries into direct edges
+            const expandedTargets = parallelTriggerTargets.get(targetNodeId);
+            if (expandedTargets) {
+              for (const actualTarget of expandedTargets) {
+                edges.push(this.createEdge(triggerNodes[i].id, actualTarget));
+              }
+            } else {
+              edges.push(this.createEdge(triggerNodes[i].id, targetNodeId));
+            }
           }
         }
       } else {
@@ -722,6 +745,59 @@ export class YamlParser {
   }
 
   /**
+   * Extract target node IDs from a synthetic __parallel_trigger_* block's parallel items.
+   * Non-action nodes use system_log.write with "Node: <id>" messages.
+   * Action nodes are matched against nodeInfoMap by comparing action properties.
+   */
+  private extractParallelTargetIds(
+    parallelItems: unknown[] | undefined,
+    nodeInfoMap: Map<string, { nodeType: string; data: Record<string, unknown> }>
+  ): string[] {
+    if (!parallelItems) return [];
+
+    const targetIds: string[] = [];
+    const matchedNodeIds = new Set<string>();
+
+    for (const item of parallelItems) {
+      const pItem = item as Record<string, unknown>;
+      const service = (pItem.service || pItem.action) as string | undefined;
+
+      // Non-action nodes: { service: 'system_log.write', data: { message: 'Node: <id>' } }
+      if (service === 'system_log.write') {
+        const data = pItem.data as Record<string, unknown> | undefined;
+        const message = data?.message as string | undefined;
+        if (message) {
+          const nodeMatch = message.match(/^Node:\s*(.+)$/);
+          if (nodeMatch) {
+            targetIds.push(nodeMatch[1]);
+            continue;
+          }
+        }
+      }
+
+      // Action nodes: match by comparing action properties against nodeInfoMap
+      if (service) {
+        for (const [candidateId, info] of nodeInfoMap) {
+          if (matchedNodeIds.has(candidateId)) continue;
+          if (info.nodeType !== 'action') continue;
+
+          const cService = info.data.service as string | undefined;
+          if (service !== cService) continue;
+          if (pItem.alias !== info.data.alias) continue;
+          if (JSON.stringify(pItem.target) !== JSON.stringify(info.data.target)) continue;
+          if (JSON.stringify(pItem.data) !== JSON.stringify(info.data.data)) continue;
+
+          targetIds.push(candidateId);
+          matchedNodeIds.add(candidateId);
+          break;
+        }
+      }
+    }
+
+    return targetIds;
+  }
+
+  /**
    * Parse a single choose block from state-machine format
    */
   private parseStateMachineChooseBlock(chooseBlock: Record<string, unknown>): {
@@ -730,6 +806,7 @@ export class YamlParser {
     data: Record<string, unknown>;
     trueTarget: string | null;
     falseTarget: string | null;
+    parallelItems?: unknown[];
   } | null {
     const conditions = chooseBlock.conditions;
     if (!Array.isArray(conditions) || conditions.length === 0) {
@@ -755,6 +832,7 @@ export class YamlParser {
     const data: Record<string, unknown> = {};
     let trueTarget: string | null = null;
     let falseTarget: string | null = null;
+    let parallelItems: unknown[] | undefined;
 
     for (const item of sequence) {
       const seqItem = item as Record<string, unknown>;
@@ -804,6 +882,10 @@ export class YamlParser {
         }
         if (seqItem.alias) data.alias = seqItem.alias;
       }
+      // Check for parallel block (synthetic __parallel_trigger_* entries)
+      else if (Array.isArray(seqItem.parallel)) {
+        parallelItems = seqItem.parallel;
+      }
       // Check for service call action
       else if (seqItem.service || seqItem.action) {
         nodeType = 'action';
@@ -814,7 +896,7 @@ export class YamlParser {
       }
     }
 
-    return { nodeId, nodeType, data, trueTarget, falseTarget };
+    return { nodeId, nodeType, data, trueTarget, falseTarget, parallelItems };
   }
 
   /**

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -142,6 +142,19 @@ function isEventAction(action: unknown): action is Record<string, unknown> {
     typeof (action as Record<string, unknown>).event === 'string'
   );
 }
+
+/**
+ * Information about a node parsed from a state-machine choose block or inline parallel branch
+ */
+interface StateMachineNodeInfo {
+  nodeId: string;
+  nodeType: 'action' | 'condition' | 'delay' | 'wait';
+  data: Record<string, unknown>;
+  trueTarget: string | null;
+  falseTarget: string | null;
+  parallelItems?: unknown[];
+}
+
 /**
  * Result of parsing YAML
  */
@@ -521,17 +534,7 @@ export class YamlParser {
     }
 
     let entryNodeId: string | null = null;
-    const nodeInfoMap = new Map<
-      string,
-      {
-        nodeId: string;
-        nodeType: 'action' | 'condition' | 'delay' | 'wait';
-        data: Record<string, unknown>;
-        trueTarget: string | null;
-        falseTarget: string | null;
-        parallelItems?: unknown[];
-      }
-    >();
+    const nodeInfoMap = new Map<string, StateMachineNodeInfo>();
 
     for (const action of actions) {
       const actionObj = action as Record<string, unknown>;
@@ -575,7 +578,7 @@ export class YamlParser {
     for (const [nodeId, info] of nodeInfoMap) {
       if (!/^__parallel_trigger_\d+$/.test(nodeId)) continue;
 
-      const targetIds = this.extractParallelTargetIds(info.parallelItems);
+      const targetIds = this.parseInlineParallelBranches(info.parallelItems ?? [], nodeInfoMap);
       if (targetIds.length > 0) {
         parallelTriggerTargets.set(nodeId, targetIds);
       }
@@ -689,7 +692,7 @@ export class YamlParser {
           id: `edge-${nodeId}-${info.trueTarget}`,
           source: nodeId,
           target: info.trueTarget,
-          sourceHandle: info.falseTarget ? 'true' : undefined,
+          sourceHandle: info.nodeType === 'condition' || info.falseTarget ? 'true' : undefined,
         });
       }
       if (info.falseTarget && info.falseTarget !== 'END') {
@@ -745,27 +748,41 @@ export class YamlParser {
   }
 
   /**
-   * Extract target node IDs from a synthetic __parallel_trigger_* block's parallel items.
-   * Supports two formats:
-   * - New: each branch tagged with alias "parallel_branch:<nodeId>"
-   * - Legacy: system_log.write with data.message "Node: <nodeId>"
+   * Parse inline parallel branch items into nodes and edges.
+   * Reconstructs the subgraph that was inlined by the transpiler's generateInlineBranch.
+   * Returns the root node IDs of each branch (for trigger→target edge creation).
    */
-  private extractParallelTargetIds(parallelItems: unknown[] | undefined): string[] {
-    if (!parallelItems) return [];
-
+  private parseInlineParallelBranches(
+    parallelItems: unknown[],
+    nodeInfoMap: Map<string, StateMachineNodeInfo>
+  ): string[] {
     const targetIds: string[] = [];
+    let idCounter = 0;
+
+    const generateId = (type: string): string => `inline_${type}_${idCounter++}`;
 
     for (const item of parallelItems) {
       const pItem = item as Record<string, unknown>;
       const alias = pItem.alias as string | undefined;
 
       // New format: { alias: "parallel_branch:<nodeId>", ... }
-      if (alias) {
-        const branchMatch = alias.match(/^parallel_branch:(.+)$/);
-        if (branchMatch) {
-          targetIds.push(branchMatch[1]);
-          continue;
+      const branchMatch = alias?.match(/^parallel_branch:(.+)$/);
+      if (branchMatch) {
+        const rootNodeId = branchMatch[1];
+        targetIds.push(rootNodeId);
+
+        // Parse the branch content into nodes
+        if (Array.isArray(pItem.sequence)) {
+          this.parseInlineActionList(
+            pItem.sequence as Record<string, unknown>[],
+            rootNodeId,
+            nodeInfoMap,
+            generateId
+          );
+        } else {
+          this.parseInlineActionItem(pItem, rootNodeId, nodeInfoMap, generateId);
         }
+        continue;
       }
 
       // Legacy format: { action: "system_log.write", data: { message: "Node: <nodeId>" } }
@@ -786,16 +803,137 @@ export class YamlParser {
   }
 
   /**
+   * Parse a list of inline HA actions, chaining them sequentially.
+   * The first action uses firstNodeId; subsequent actions get generated IDs.
+   */
+  private parseInlineActionList(
+    actions: Record<string, unknown>[],
+    firstNodeId: string,
+    nodeInfoMap: Map<string, StateMachineNodeInfo>,
+    generateId: (type: string) => string
+  ): void {
+    let prevNodeId: string | null = null;
+
+    for (let i = 0; i < actions.length; i++) {
+      const action = actions[i];
+      const { nodeId: embeddedId } = this.extractCafeNodeId(action.alias as string | undefined);
+      const nodeId = i === 0 ? firstNodeId : (embeddedId ?? generateId(this.inferInlineNodeType(action)));
+
+      // Chain previous non-condition node to this one
+      if (prevNodeId) {
+        const prevInfo = nodeInfoMap.get(prevNodeId);
+        if (prevInfo && prevInfo.nodeType !== 'condition') {
+          prevInfo.trueTarget = nodeId;
+        }
+      }
+
+      this.parseInlineActionItem(action, nodeId, nodeInfoMap, generateId);
+      prevNodeId = nodeId;
+    }
+  }
+
+  /**
+   * Parse a single inline HA action item into a StateMachineNodeInfo entry.
+   * Handles actions, conditions (if/then/else), delays, and waits.
+   */
+  private parseInlineActionItem(
+    item: Record<string, unknown>,
+    nodeId: string,
+    nodeInfoMap: Map<string, StateMachineNodeInfo>,
+    generateId: (type: string) => string
+  ): void {
+    // Strip parallel_branch: prefix from alias if present
+    const rawAlias = item.alias as string | undefined;
+    const { cleanAlias: cafeStripped } = this.extractCafeNodeId(rawAlias);
+    const alias = cafeStripped?.startsWith('parallel_branch:') ? undefined : cafeStripped;
+
+    if (item.if && Array.isArray(item.if)) {
+      // Condition node (if/then/else)
+      const conditions = item.if as Record<string, unknown>[];
+      const condition = conditions[0] ?? {};
+      const data: Record<string, unknown> = { ...condition };
+      if (alias) data.alias = alias;
+
+      let trueTarget: string | null = null;
+      let falseTarget: string | null = null;
+
+      const thenActions = item.then as Record<string, unknown>[] | undefined;
+      if (thenActions && thenActions.length > 0) {
+        const { nodeId: thenEmbeddedId } = this.extractCafeNodeId(thenActions[0].alias as string | undefined);
+        const thenNodeId = thenEmbeddedId ?? generateId(this.inferInlineNodeType(thenActions[0]));
+        trueTarget = thenNodeId;
+        this.parseInlineActionList(thenActions, thenNodeId, nodeInfoMap, generateId);
+      }
+
+      const elseActions = item.else as Record<string, unknown>[] | undefined;
+      if (elseActions && elseActions.length > 0) {
+        const { nodeId: elseEmbeddedId } = this.extractCafeNodeId(elseActions[0].alias as string | undefined);
+        const elseNodeId = elseEmbeddedId ?? generateId(this.inferInlineNodeType(elseActions[0]));
+        falseTarget = elseNodeId;
+        this.parseInlineActionList(elseActions, elseNodeId, nodeInfoMap, generateId);
+      }
+
+      nodeInfoMap.set(nodeId, { nodeId, nodeType: 'condition', data, trueTarget, falseTarget });
+    } else if (item.service || item.action) {
+      // Action node
+      const data: Record<string, unknown> = {};
+      data.service = (item.service ?? item.action) as string;
+      if (item.target) data.target = item.target;
+      if (item.data) data.data = item.data;
+      if (alias) data.alias = alias;
+
+      nodeInfoMap.set(nodeId, { nodeId, nodeType: 'action', data, trueTarget: null, falseTarget: null });
+    } else if (item.delay !== undefined) {
+      // Delay node
+      const data: Record<string, unknown> = { delay: item.delay };
+      if (alias) data.alias = alias;
+
+      nodeInfoMap.set(nodeId, { nodeId, nodeType: 'delay', data, trueTarget: null, falseTarget: null });
+    } else if (item.wait_template !== undefined || item.wait_for_trigger !== undefined) {
+      // Wait node
+      const data: Record<string, unknown> = {};
+      if (item.wait_template) data.wait_template = item.wait_template;
+      if (item.wait_for_trigger) data.wait_for_trigger = item.wait_for_trigger;
+      if (item.timeout) data.timeout = item.timeout;
+      if (item.continue_on_timeout !== undefined) data.continue_on_timeout = item.continue_on_timeout;
+      if (alias) data.alias = alias;
+
+      nodeInfoMap.set(nodeId, { nodeId, nodeType: 'wait', data, trueTarget: null, falseTarget: null });
+    }
+  }
+
+  /**
+   * Extract a C.A.F.E. node ID encoded in an alias field.
+   * Handles format: "cafe_node:<nodeId>" or "cafe_node:<nodeId>:<userAlias>"
+   */
+  private extractCafeNodeId(alias: string | undefined): {
+    nodeId: string | null;
+    cleanAlias: string | undefined;
+  } {
+    if (!alias) return { nodeId: null, cleanAlias: undefined };
+    const match = alias.match(/^cafe_node:([^:]+)(?::(.+))?$/);
+    if (match) {
+      return { nodeId: match[1], cleanAlias: match[2] || undefined };
+    }
+    return { nodeId: null, cleanAlias: alias };
+  }
+
+  /**
+   * Infer the node type from an inline HA action item.
+   */
+  private inferInlineNodeType(item: Record<string, unknown>): string {
+    if (item.if) return 'condition';
+    if (item.delay !== undefined) return 'delay';
+    if (item.wait_template !== undefined || item.wait_for_trigger !== undefined) return 'wait';
+    return 'action';
+  }
+
+  /**
    * Parse a single choose block from state-machine format
    */
-  private parseStateMachineChooseBlock(chooseBlock: Record<string, unknown>): {
-    nodeId: string;
-    nodeType: 'action' | 'condition' | 'delay' | 'wait';
-    data: Record<string, unknown>;
-    trueTarget: string | null;
-    falseTarget: string | null;
-    parallelItems?: unknown[];
-  } | null {
+  private parseStateMachineChooseBlock(
+    chooseBlock: Record<string, unknown>
+  ): StateMachineNodeInfo | null {
     const conditions = chooseBlock.conditions;
     if (!Array.isArray(conditions) || conditions.length === 0) {
       return null;

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -746,8 +746,9 @@ export class YamlParser {
 
   /**
    * Extract target node IDs from a synthetic __parallel_trigger_* block's parallel items.
-   * Each parallel branch is tagged with an alias of the form "parallel_branch:<nodeId>"
-   * by the transpiler, making identification straightforward.
+   * Supports two formats:
+   * - New: each branch tagged with alias "parallel_branch:<nodeId>"
+   * - Legacy: system_log.write with data.message "Node: <nodeId>"
    */
   private extractParallelTargetIds(parallelItems: unknown[] | undefined): string[] {
     if (!parallelItems) return [];
@@ -758,11 +759,25 @@ export class YamlParser {
       const pItem = item as Record<string, unknown>;
       const alias = pItem.alias as string | undefined;
 
-      // Each branch is tagged: { alias: "parallel_branch:<nodeId>", ... }
+      // New format: { alias: "parallel_branch:<nodeId>", ... }
       if (alias) {
         const branchMatch = alias.match(/^parallel_branch:(.+)$/);
         if (branchMatch) {
           targetIds.push(branchMatch[1]);
+          continue;
+        }
+      }
+
+      // Legacy format: { action: "system_log.write", data: { message: "Node: <nodeId>" } }
+      const action = (pItem.service ?? pItem.action) as string | undefined;
+      if (action === 'system_log.write') {
+        const data = pItem.data as Record<string, unknown> | undefined;
+        const message = data?.message as string | undefined;
+        if (message) {
+          const nodeMatch = message.match(/^Node:\s*(.+)$/);
+          if (nodeMatch) {
+            targetIds.push(nodeMatch[1]);
+          }
         }
       }
     }

--- a/packages/transpiler/src/strategies/state-machine.ts
+++ b/packages/transpiler/src/strategies/state-machine.ts
@@ -74,15 +74,26 @@ export class StateMachineStrategy extends BaseStrategy {
       };
     }
 
-    // Build choose blocks for each non-trigger node
-    const nodeBlocks = flow.nodes
-      .filter((n) => n.type !== 'trigger')
-      .map((node) => this.generateNodeBlock(flow, node));
-
     // Generate parallel entry blocks for triggers with multiple targets
     const parallelEntryBlocks = this.generateParallelEntryBlocks(flow, triggerRouting);
 
-    // Combine node blocks and parallel entry blocks
+    // Collect node IDs consumed by parallel branches so they aren't
+    // duplicated as standalone state-machine choose entries
+    const parallelConsumedNodeIds = new Set<string>();
+    for (const [, targets] of triggerRouting) {
+      if (targets.length > 1) {
+        for (const targetId of targets) {
+          this.collectSubgraphNodeIds(flow, targetId, parallelConsumedNodeIds);
+        }
+      }
+    }
+
+    // Build choose blocks for each non-trigger node not already inlined in a parallel branch
+    const nodeBlocks = flow.nodes
+      .filter((n) => n.type !== 'trigger' && !parallelConsumedNodeIds.has(n.id))
+      .map((node) => this.generateNodeBlock(flow, node));
+
+    // Combine parallel entry blocks and remaining node blocks
     const chooseBlocks = [...parallelEntryBlocks, ...nodeBlocks];
 
     // Warn about potential infinite loops
@@ -310,6 +321,34 @@ export class StateMachineStrategy extends BaseStrategy {
   }
 
   /**
+   * Collect all node IDs reachable from a starting node (used to identify
+   * nodes that are already inlined inside parallel branches).
+   */
+  private collectSubgraphNodeIds(flow: FlowGraph, nodeId: string, collected: Set<string>): void {
+    if (nodeId === 'END' || collected.has(nodeId)) return;
+
+    const node = flow.nodes.find((n) => n.id === nodeId);
+    if (!node || node.type === 'trigger') return;
+
+    collected.add(nodeId);
+    const edges = this.getOutgoingEdges(flow, node.id);
+    for (const edge of edges) {
+      this.collectSubgraphNodeIds(flow, edge.target, collected);
+    }
+  }
+
+  /**
+   * Encode a C.A.F.E. node ID into the alias field so it survives the HA round-trip.
+   * Format: "cafe_node:<nodeId>" or "cafe_node:<nodeId>:<userAlias>"
+   */
+  private encodeNodeIdInAlias(action: Record<string, unknown>, nodeId: string): void {
+    const existingAlias = action.alias as string | undefined;
+    action.alias = existingAlias
+      ? `cafe_node:${nodeId}:${existingAlias}`
+      : `cafe_node:${nodeId}`;
+  }
+
+  /**
    * Generate an inline HA action sequence for a subgraph starting at the given node.
    * Used within parallel branches where each branch must be self-contained
    * (no current_node state machine variable).
@@ -332,6 +371,7 @@ export class StateMachineStrategy extends BaseStrategy {
     switch (node.type) {
       case 'action': {
         const actionCall = this.buildActionCall(node as ActionNode);
+        this.encodeNodeIdInAlias(actionCall, node.id);
         const nextNodeId = edges[0]?.target ?? 'END';
         return [actionCall, ...this.generateInlineBranch(flow, nextNodeId, visited)];
       }
@@ -352,6 +392,7 @@ export class StateMachineStrategy extends BaseStrategy {
           if: [condition],
           then: thenActions,
         };
+        this.encodeNodeIdInAlias(ifBlock, node.id);
         if (elseActions.length > 0) {
           ifBlock.else = elseActions;
         }
@@ -360,18 +401,21 @@ export class StateMachineStrategy extends BaseStrategy {
 
       case 'delay': {
         const delayAction = this.buildDelayAction(node as DelayNode);
+        this.encodeNodeIdInAlias(delayAction, node.id);
         const nextNodeId = edges[0]?.target ?? 'END';
         return [delayAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
       }
 
       case 'wait': {
         const waitAction = this.buildWaitAction(node as WaitNode);
+        this.encodeNodeIdInAlias(waitAction, node.id);
         const nextNodeId = edges[0]?.target ?? 'END';
         return [waitAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
       }
 
       case 'set_variables': {
         const setVarsAction = this.buildSetVariablesAction(node as SetVariablesNode);
+        this.encodeNodeIdInAlias(setVarsAction, node.id);
         const nextNodeId = edges[0]?.target ?? 'END';
         return [setVarsAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
       }

--- a/packages/transpiler/src/strategies/state-machine.ts
+++ b/packages/transpiler/src/strategies/state-machine.ts
@@ -270,21 +270,20 @@ export class StateMachineStrategy extends BaseStrategy {
 
       const parallelEntryId = `__parallel_trigger_${idx}`;
 
-      // Build parallel action calls for all target nodes
-      const parallelActions = targets.map((targetId) => {
-        const targetNode = flow.nodes.find((n) => n.id === targetId);
-        if (!targetNode) {
-          return { service: 'system_log.write', data: { message: `Unknown node: ${targetId}` } };
+      // Build self-contained inline branches for all target nodes.
+      // Each branch gets a "parallel_branch:<nodeId>" alias so the parser
+      // can identify which node each branch corresponds to.
+      const parallelBranches = targets.map((targetId) => {
+        const inlineActions = this.generateInlineBranch(flow, targetId, new Set());
+        if (inlineActions.length === 0) {
+          return { alias: `parallel_branch:${targetId}`, stop: 'Empty branch' };
         }
-
-        // Generate the action call based on node type
-        if (targetNode.type === 'action') {
-          return this.buildActionCall(targetNode as ActionNode);
+        if (inlineActions.length === 1) {
+          // Single action — spread first, then override alias with branch identifier
+          return { ...inlineActions[0], alias: `parallel_branch:${targetId}` };
         }
-
-        // For non-action nodes, we need to execute them and continue
-        // This is a simplified case - complex parallel branches would need more work
-        return { service: 'system_log.write', data: { message: `Node: ${targetId}` } };
+        // Multiple actions — wrap in a sequence
+        return { alias: `parallel_branch:${targetId}`, sequence: inlineActions };
       });
 
       parallelBlocks.push({
@@ -296,7 +295,7 @@ export class StateMachineStrategy extends BaseStrategy {
         ],
         sequence: [
           {
-            parallel: parallelActions,
+            parallel: parallelBranches,
           },
           {
             variables: {
@@ -308,6 +307,81 @@ export class StateMachineStrategy extends BaseStrategy {
     }
 
     return parallelBlocks;
+  }
+
+  /**
+   * Generate an inline HA action sequence for a subgraph starting at the given node.
+   * Used within parallel branches where each branch must be self-contained
+   * (no current_node state machine variable).
+   */
+  private generateInlineBranch(
+    flow: FlowGraph,
+    nodeId: string,
+    visited: Set<string>
+  ): Record<string, unknown>[] {
+    if (nodeId === 'END' || visited.has(nodeId)) {
+      return [];
+    }
+
+    const node = flow.nodes.find((n) => n.id === nodeId);
+    if (!node) return [];
+
+    visited.add(nodeId);
+    const edges = this.getOutgoingEdges(flow, node.id);
+
+    switch (node.type) {
+      case 'action': {
+        const actionCall = this.buildActionCall(node as ActionNode);
+        const nextNodeId = edges[0]?.target ?? 'END';
+        return [actionCall, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+      }
+
+      case 'condition': {
+        const trueEdge = edges.find((e) => e.sourceHandle === 'true');
+        const falseEdge = edges.find((e) => e.sourceHandle === 'false');
+        const trueTarget = trueEdge?.target ?? 'END';
+        const falseTarget = falseEdge?.target ?? 'END';
+
+        const condition = this.buildNativeCondition(node as ConditionNode);
+        // Each branch gets its own visited copy so independent paths don't block each other
+        const thenActions = this.generateInlineBranch(flow, trueTarget, new Set(visited));
+        const elseActions = this.generateInlineBranch(flow, falseTarget, new Set(visited));
+
+        const ifBlock: Record<string, unknown> = {
+          alias: (node as ConditionNode).data.alias,
+          if: [condition],
+          then: thenActions,
+        };
+        if (elseActions.length > 0) {
+          ifBlock.else = elseActions;
+        }
+        return [ifBlock];
+      }
+
+      case 'delay': {
+        const delayAction = this.buildDelayAction(node as DelayNode);
+        const nextNodeId = edges[0]?.target ?? 'END';
+        return [delayAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+      }
+
+      case 'wait': {
+        const waitAction = this.buildWaitAction(node as WaitNode);
+        const nextNodeId = edges[0]?.target ?? 'END';
+        return [waitAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+      }
+
+      case 'set_variables': {
+        const setVarsAction = this.buildSetVariablesAction(node as SetVariablesNode);
+        const nextNodeId = edges[0]?.target ?? 'END';
+        return [setVarsAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+      }
+
+      default: {
+        // Unknown node type — skip it and continue to the next node
+        const nextNodeId = edges[0]?.target ?? 'END';
+        return this.generateInlineBranch(flow, nextNodeId, visited);
+      }
+    }
   }
 
   /**
@@ -654,13 +728,9 @@ export class StateMachineStrategy extends BaseStrategy {
   }
 
   /**
-   * Generate block for delay node
+   * Build a delay action from a delay node (without state-machine wrapper)
    */
-  private generateDelayBlock(node: DelayNode, edges: FlowEdge[]): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
-    const currentNodeId = node.id;
-
+  private buildDelayAction(node: DelayNode): Record<string, unknown> {
     // Use spread pattern to preserve unknown properties from custom integrations
     const { alias, delay, id, ...extraProps } = node.data;
     const delayAction: Record<string, unknown> = {
@@ -673,6 +743,17 @@ export class StateMachineStrategy extends BaseStrategy {
       delayAction.id = id;
     }
 
+    return delayAction;
+  }
+
+  /**
+   * Generate block for delay node
+   */
+  private generateDelayBlock(node: DelayNode, edges: FlowEdge[]): Record<string, unknown> {
+    const nextNodeId = edges[0]?.target ?? 'END';
+    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+    const currentNodeId = node.id;
+
     return {
       conditions: [
         {
@@ -681,7 +762,7 @@ export class StateMachineStrategy extends BaseStrategy {
         },
       ],
       sequence: [
-        delayAction,
+        this.buildDelayAction(node),
         {
           variables: {
             current_node: nextNode,
@@ -692,13 +773,9 @@ export class StateMachineStrategy extends BaseStrategy {
   }
 
   /**
-   * Generate block for wait node
+   * Build a wait action from a wait node (without state-machine wrapper)
    */
-  private generateWaitBlock(node: WaitNode, edges: FlowEdge[]): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
-    const currentNodeId = node.id;
-
+  private buildWaitAction(node: WaitNode): Record<string, unknown> {
     // Use spread pattern to preserve unknown properties from custom integrations
     const {
       alias,
@@ -738,6 +815,17 @@ export class StateMachineStrategy extends BaseStrategy {
       waitAction.continue_on_timeout = continue_on_timeout;
     }
 
+    return waitAction;
+  }
+
+  /**
+   * Generate block for wait node
+   */
+  private generateWaitBlock(node: WaitNode, edges: FlowEdge[]): Record<string, unknown> {
+    const nextNodeId = edges[0]?.target ?? 'END';
+    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+    const currentNodeId = node.id;
+
     return {
       conditions: [
         {
@@ -746,7 +834,7 @@ export class StateMachineStrategy extends BaseStrategy {
         },
       ],
       sequence: [
-        waitAction,
+        this.buildWaitAction(node),
         {
           variables: {
             current_node: nextNode,
@@ -757,16 +845,9 @@ export class StateMachineStrategy extends BaseStrategy {
   }
 
   /**
-   * Generate block for set_variables node
+   * Build a set_variables action from a set_variables node (without state-machine wrapper)
    */
-  private generateSetVariablesBlock(
-    node: SetVariablesNode,
-    edges: FlowEdge[]
-  ): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
-    const currentNodeId = node.id;
-
+  private buildSetVariablesAction(node: SetVariablesNode): Record<string, unknown> {
     // Use spread pattern to preserve unknown properties from custom integrations
     const { alias, id, variables, ...extraProps } = node.data;
     const setVarsAction: Record<string, unknown> = {
@@ -782,6 +863,20 @@ export class StateMachineStrategy extends BaseStrategy {
       setVarsAction.id = id;
     }
 
+    return setVarsAction;
+  }
+
+  /**
+   * Generate block for set_variables node
+   */
+  private generateSetVariablesBlock(
+    node: SetVariablesNode,
+    edges: FlowEdge[]
+  ): Record<string, unknown> {
+    const nextNodeId = edges[0]?.target ?? 'END';
+    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+    const currentNodeId = node.id;
+
     return {
       conditions: [
         {
@@ -790,7 +885,7 @@ export class StateMachineStrategy extends BaseStrategy {
         },
       ],
       sequence: [
-        setVarsAction,
+        this.buildSetVariablesAction(node),
         {
           variables: {
             current_node: nextNode,


### PR DESCRIPTION
## Fix phantom node on parallel trigger reimport

When a trigger fans out to multiple targets, the transpiler generates a synthetic `__parallel_trigger_N` choose block. The parser didn't recognize this construct, creating a phantom "Action" node at (0, 0) with empty data. The original targets became orphaned.

### Changes

**Phantom node fix** (`e422cf2`)
- `parseStateMachineChooseBlock` now captures `parallel` arrays from synthetic choose blocks
- New `extractParallelTargetIds` method resolves actual target IDs from the parallel items (handles both `system_log.write` placeholders and real action calls)
- Synthetic `__parallel_trigger_*` entries are removed from `nodeInfoMap` before node creation and expanded into direct trigger-to-target edges

**Type-aware ID assignment** (`ac2a202`)
- `getNextNodeId` in `parseSimpleActions` now assigns metadata IDs by node type prefix, preventing ID misordering when parsing parallel branches

### Tests

Two round-trip tests added to `parallel-trigger-branches.test.ts`:
- Trigger fan-out to multiple **action** nodes
- Trigger fan-out to multiple **condition** nodes

Both assert no `__parallel_trigger_*` phantom nodes exist and verify correct edge connectivity after a full transpile-then-parse cycle.

Should fix [issue 198](https://github.com/FezVrasta/cafe-hass/issues/198). 