### PR TITLE
Clear numeric conditions when the value is cleared

### DIFF
--- a/packages/frontend/src/components/nodes/ConditionNode.tsx
+++ b/packages/frontend/src/components/nodes/ConditionNode.tsx
@@ -94,13 +94,13 @@ export const ConditionNode = memo(function ConditionNode({
             {data.state}
           </div>
         )}
-        {data.above !== undefined && (
+        {data.above != null && (
           <div className="opacity-75">
             {'> '}
             {data.above}
           </div>
         )}
-        {data.below !== undefined && (
+        {data.below != null && (
           <div className="opacity-75">
             {'< '}
             {data.below}

--- a/packages/frontend/src/components/ui/DynamicFieldRenderer.tsx
+++ b/packages/frontend/src/components/ui/DynamicFieldRenderer.tsx
@@ -188,7 +188,7 @@ export function DynamicFieldRenderer({
           <Input
             type="number"
             value={numberValue ?? ''}
-            onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+            onChange={(e) => onChange(e.target.value ? Number(e.target.value) : undefined)}
             placeholder={placeholder}
             required={required}
           />

--- a/packages/transpiler/src/strategies/state-machine.ts
+++ b/packages/transpiler/src/strategies/state-machine.ts
@@ -614,8 +614,8 @@ export class StateMachineStrategy extends BaseStrategy {
     // Copy relevant fields based on condition type
     if (data.entity_id) condition.entity_id = data.entity_id;
     if (data.state !== undefined) condition.state = data.state;
-    if (data.above !== undefined) condition.above = data.above;
-    if (data.below !== undefined) condition.below = data.below;
+    if (data.above != null && data.above !== '') condition.above = data.above;
+    if (data.below != null && data.below !== '') condition.below = data.below;
     if (data.attribute) condition.attribute = data.attribute;
     if (data.value_template) condition.value_template = data.value_template;
     if (data.after) condition.after = data.after;
@@ -906,10 +906,10 @@ export class StateMachineStrategy extends BaseStrategy {
         ? `state_attr('${data.entity_id}', '${data.attribute}') | float`
         : `states('${data.entity_id}') | float`;
 
-    if (data.above !== undefined) {
+    if (data.above != null && data.above !== '') {
       parts.push(`${valueExpr} > ${data.above}`);
     }
-    if (data.below !== undefined) {
+    if (data.below != null && data.below !== '') {
       parts.push(`${valueExpr} < ${data.below}`);
     }
 


### PR DESCRIPTION
Fixed numeric condition nodes retaining cleared above/below values, when a user set  min and/or max, then removed one, the cleared value persisted as null instead of being treated as unset. Resulting in:

<img width="192" height="98" alt="image" src="https://github.com/user-attachments/assets/376ddd45-7ceb-4dea-8362-db3ec59a7c3d" />

While it should have been:

<img width="192" height="98" alt="image" src="https://github.com/user-attachments/assets/abd7b2de-7fbc-4ccc-9d0e-2738892ec5b0" />

--- 

DynamicFieldRenderer emitted null on cleared number inputs, but all downstream checks used !== undefined (which doesn't catch null)
Changed the number input to emit undefined on clear, and hardened display + transpiler checks to use != null