### PR TITLE
Fix: YAML-defined automation IDs are skipped when fetching config

### DIFF
--- a/packages/frontend/src/lib/ha-api.ts
+++ b/packages/frontend/src/lib/ha-api.ts
@@ -361,8 +361,9 @@ export class HomeAssistantAPI {
         }
       }
 
-      // Try numeric ID with REST API (for automations created via UI)
-      if (!automationId.startsWith('automation.') && !Number.isNaN(Number(automationId))) {
+      // REST API works for any automation with an `id:` field — both numeric
+      // (UI-created) and string IDs (YAML-defined automations in automations.yaml).
+      if (!automationId.startsWith('automation.')) {
         try {
           const config = await this.fetchRestAPI(`config/automation/config/${automationId}`);
           if (config) {
@@ -410,14 +411,22 @@ export class HomeAssistantAPI {
   }
 
   /**
-   * Get automation configuration with multiple fallback methods
+   * Get automation configuration with multiple fallback methods.
+   * Falls back to extracting the config from the most recent trace when
+   * the primary lookup returns null (e.g. when neither WebSocket nor REST
+   * can serve the config).
    */
   async getAutomationConfigWithFallback(
     automationId: string,
     _alias?: string
   ): Promise<AutomationConfig | null> {
     try {
-      return await this.getAutomationConfig(automationId);
+      const primary = await this.getAutomationConfig(automationId);
+      if (primary) {
+        return primary;
+      }
+      const fromTrace = await this.getAutomationConfigFromTrace(automationId);
+      return (fromTrace as AutomationConfig | null) ?? null;
     } catch (error) {
       console.error('C.A.F.E.: Failed to get automation config with fallback:', error);
       return null;


### PR DESCRIPTION
## Summary

`getAutomationConfig()` silently skipped the REST API call for any automation whose ID was a non-numeric string, causing the import dialog to show *"Could not fetch configuration automatically"* for every YAML-defined automation.

## Repro

1. Define an automation in `automations.yaml` (loaded via `automation: !include automations.yaml`) with a descriptive `id:` such as:
   ```yaml
   - id: aanwezigheid_welkom_eerste_thuiskomst
     alias: "Aanwezigheid - welkom bij eerste thuiskomst"
     trigger: ...
   ```
2. Open the C.A.F.E. import dialog and pick that automation.
3. Result: yellow toast *"Automation … opened! Could not fetch configuration automatically. You can now create a new flow with the same name."* and an empty graph. No request appears in the Network tab.

## Root cause

In `packages/frontend/src/lib/ha-api.ts`, `getAutomationConfig()` had this guard around the REST call:

```ts
if (!automationId.startsWith('automation.') && !Number.isNaN(Number(automationId))) {
  // fetchRestAPI(`config/automation/config/${automationId}`)
}
```

The `!Number.isNaN(Number(id))` clause was meant to distinguish "real" automation IDs (numeric timestamps from UI-storage automations) from entity IDs. However, string IDs from YAML (`id: aanwezigheid_welkom_eerste_thuiskomst`) are also valid — `Number("aanwezigheid_…")` returns `NaN`, so the entire `if` evaluates to `false` and the REST call is skipped.

The flow then falls through to `getAutomationConfigs()`, which falls back to mapping `getAutomations()` state attributes — building stub objects keyed by `entity_id.replace("automation.", "")`. The HA-derived entity ID is generated from the alias (`aanwezigheid_welkom_bij_eerste_thuiskomst` — note `bij`), while the catalog's `automation_id` came from `attributes.id` (`aanwezigheid_welkom_eerste_thuiskomst` — no `bij`). The `.find()` mismatch returns `null`, the import dialog shows the warning toast.

HA's REST endpoint `/api/config/automation/config/<id>` accepts both numeric and string IDs as long as the automation has an `id:` field and lives in a writable YAML source — exactly our case. Dropping the numeric guard fixes the primary path.

## Changes

1. **`getAutomationConfig`** — drop the `!Number.isNaN(Number(...))` check; only the `automation.`-prefix guard remains so we don't pass entity IDs to the config endpoint.
2. **`getAutomationConfigWithFallback`** — actually use `getAutomationConfigFromTrace` as a fallback when the primary lookup returns `null`. The name implied a fallback existed, but the previous body just delegated to `getAutomationConfig` and surfaced its `null`. Now traces serve as a last-resort source for the config (e.g. when the YAML is in a non-writable location but a trace was captured).

## Test plan

- [x] Typecheck: `yarn typecheck` ✓
- [x] Build: `yarn build` ✓
- [x] Manual: opened a YAML-defined automation with a string `id:` against a real HA instance — the REST request now fires, returns the config, and the graph renders triggers/conditions/actions.
- [x] Existing UI-storage automations (numeric IDs) continue to work — they still match the new condition (`!automationId.startsWith('automation.')`).