### PR TITLE
fix(transpiler): make the state-machine round-trip lossless (#228, #212)

### DIFF
--- a/packages/transpiler/src/__tests__/state-machine-roundtrip-fanout.test.ts
+++ b/packages/transpiler/src/__tests__/state-machine-roundtrip-fanout.test.ts
@@ -614,3 +614,193 @@ describe('fan-out safety: never delete a dispatcher entry something still jumps 
     expect(warnings.some((w) => w.includes('Z'))).toBe(true);
   });
 });
+
+/**
+ * A fan-out claims its subgraph, so planning order decides who wins. These
+ * guard the diagnostics and determinism of that planning.
+ */
+describe('fan-out planning is deterministic and honestly reported', () => {
+  const transpile = (flow: FlowGraph) =>
+    new FlowTranspiler().transpile(flow, { forceStrategy: 'state-machine' });
+
+  /** A → B, A → C, B → D, B → E — a two-level fan-out. */
+  const twoLevelNodes: FlowGraph['nodes'] = [
+    ...TRIGGERS,
+    { id: 'A', type: 'action', position: { x: 300, y: 100 }, data: { service: 'scene.create' } },
+    { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+    { id: 'C', type: 'action', position: { x: 600, y: 300 }, data: { service: 'light.turn_off' } },
+    { id: 'D', type: 'action', position: { x: 900, y: -100 }, data: { service: 'switch.turn_on' } },
+    { id: 'E', type: 'action', position: { x: 900, y: 100 }, data: { service: 'switch.turn_off' } },
+  ];
+  const twoLevelEdges: FlowGraph['edges'] = [
+    { id: 'e0', source: 'trigger_0', target: 'A' },
+    { id: 'e1', source: 'trigger_1', target: 'A' },
+    { id: 'e2', source: 'A', target: 'B' },
+    { id: 'e3', source: 'A', target: 'C' },
+    { id: 'e4', source: 'B', target: 'D' },
+    { id: 'e5', source: 'B', target: 'E' },
+  ];
+
+  it('produces identical output regardless of node array order', async () => {
+    const inOrder: FlowGraph = {
+      id: 'cccccccc-dddd-4eee-8fff-000000000001',
+      version: 1,
+      name: 'Two level',
+      nodes: twoLevelNodes,
+      edges: twoLevelEdges,
+    };
+    // Nested node B declared before its ancestor A
+    const reordered: FlowGraph = {
+      ...inOrder,
+      nodes: [
+        ...TRIGGERS,
+        ...['B', 'A', 'C', 'D', 'E'].map(
+          (id) => twoLevelNodes.find((n) => n.id === id) as FlowGraph['nodes'][number]
+        ),
+      ],
+    };
+
+    const a = transpile(inOrder);
+    const b = transpile(reordered);
+    if (!a.yaml || !b.yaml) throw new Error('expected generated yaml');
+
+    // Node order is a UI detail and must not change the generated automation
+    expect(b.yaml).toBe(a.yaml);
+
+    // and no edge may be lost in either ordering
+    for (const yaml of [a.yaml, b.yaml]) {
+      const parsed = await new YamlParser().parse(yaml);
+      const pairs = (parsed.graph?.edges ?? [])
+        .filter((e) => !e.source.startsWith('trigger'))
+        .map((e) => `${e.source}->${e.target}`)
+        .sort();
+      expect(pairs).toEqual(['A->B', 'A->C', 'B->D', 'B->E']);
+    }
+  });
+
+  it('does not warn about a nested fan-out that works correctly', () => {
+    const flow: FlowGraph = {
+      id: 'cccccccc-dddd-4eee-8fff-000000000002',
+      version: 1,
+      name: 'Nested no warning',
+      nodes: twoLevelNodes,
+      edges: twoLevelEdges,
+    };
+
+    const { warnings } = transpile(flow);
+    // B's branches are not shared and both do run — claiming otherwise is a lie
+    expect(warnings.filter((w) => w.includes('only the first branch will run'))).toEqual([]);
+  });
+
+  it('still warns when a nested fan-out re-joins', () => {
+    // A → B,C ; B → D,E ; D → J ; E → J : J is inlined into both D and E
+    const flow: FlowGraph = {
+      id: 'cccccccc-dddd-4eee-8fff-000000000003',
+      version: 1,
+      name: 'Nested join',
+      nodes: [
+        ...twoLevelNodes,
+        {
+          id: 'J',
+          type: 'action',
+          position: { x: 1200, y: 0 },
+          data: { service: 'notify.notify' },
+        },
+      ],
+      edges: [
+        ...twoLevelEdges,
+        { id: 'e6', source: 'D', target: 'J' },
+        { id: 'e7', source: 'E', target: 'J' },
+      ],
+    };
+
+    const { warnings } = transpile(flow);
+    expect(warnings.some((w) => w.includes('Nodes [J]'))).toBe(true);
+  });
+
+  it('de-dupes duplicate edges inside a nested branch', async () => {
+    const flow: FlowGraph = {
+      id: 'cccccccc-dddd-4eee-8fff-000000000004',
+      version: 1,
+      name: 'Nested duplicate edges',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'A',
+          type: 'action',
+          position: { x: 300, y: 100 },
+          data: { service: 'scene.create' },
+        },
+        { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 300 },
+          data: { service: 'light.turn_off' },
+        },
+        {
+          id: 'D',
+          type: 'action',
+          position: { x: 900, y: 0 },
+          data: { service: 'switch.turn_on' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'A' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+        { id: 'e4', source: 'B', target: 'D' },
+        { id: 'e5', source: 'B', target: 'D' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // D must be emitted once, not once per duplicate edge
+    expect(yaml.match(/parallel_branch:D/g) ?? []).toHaveLength(0);
+    expect(yaml.match(/cafe_node:D/g) ?? []).toHaveLength(1);
+
+    const result = await new YamlParser().parse(yaml);
+    expect(result.success).toBe(true);
+  });
+
+  it('round-trips a single trigger that fans out', async () => {
+    // One trigger with several targets yields a bare __parallel_trigger_0 entry
+    // rather than a routing template.
+    const flow: FlowGraph = {
+      id: 'cccccccc-dddd-4eee-8fff-000000000005',
+      version: 1,
+      name: 'Single trigger fan-out',
+      nodes: [
+        TRIGGERS[0],
+        { id: 'X', type: 'action', position: { x: 300, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'Y',
+          type: 'action',
+          position: { x: 300, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'X' },
+        { id: 'e1', source: 'trigger_0', target: 'Y' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    const result = await new YamlParser().parse(yaml);
+    // Previously the trigger edge pointed at the deleted synthetic entry
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.success).toBe(true);
+
+    const targets = (result.graph?.edges ?? [])
+      .filter((e) => e.source === 'trigger_0')
+      .map((e) => e.target)
+      .sort();
+    expect(targets).toEqual(['X', 'Y']);
+  });
+});

--- a/packages/transpiler/src/__tests__/state-machine-roundtrip-fanout.test.ts
+++ b/packages/transpiler/src/__tests__/state-machine-roundtrip-fanout.test.ts
@@ -1,0 +1,616 @@
+import type { FlowGraph } from '@cafe/shared';
+import { describe, expect, it } from 'vitest';
+import { FlowTranspiler } from '../FlowTranspiler';
+import { YamlParser } from '../parser/YamlParser';
+
+/**
+ * The state-machine strategy is selected whenever a flow has 2+ triggers.
+ * These tests cover the round-trip losses reported in:
+ *   #228 — fan-out after an action ran only the first branch
+ *   #212 — set_variables nodes came back as empty action nodes
+ */
+
+/** Two triggers force the state-machine strategy. */
+const TRIGGERS: FlowGraph['nodes'] = [
+  {
+    id: 'trigger_0',
+    type: 'trigger',
+    position: { x: 0, y: 0 },
+    data: { trigger: 'state', entity_id: ['binary_sensor.a'] },
+  },
+  {
+    id: 'trigger_1',
+    type: 'trigger',
+    position: { x: 0, y: 200 },
+    data: { trigger: 'state', entity_id: ['binary_sensor.b'] },
+  },
+];
+
+describe('Issue #228 - fan-out after an action drops all but the first branch', () => {
+  const flow: FlowGraph = {
+    id: '11111111-2222-4333-8444-555555555555',
+    version: 1,
+    name: 'Scene then parallel lights',
+    nodes: [
+      ...TRIGGERS,
+      {
+        id: 'act_scene_create',
+        type: 'action',
+        position: { x: 300, y: 100 },
+        data: { service: 'scene.create' },
+      },
+      {
+        id: 'act_l1',
+        type: 'action',
+        position: { x: 600, y: 0 },
+        data: { service: 'light.turn_on', target: { entity_id: 'light.one' } },
+      },
+      {
+        id: 'act_l2',
+        type: 'action',
+        position: { x: 600, y: 150 },
+        data: { service: 'light.turn_on', target: { entity_id: 'light.two' } },
+      },
+      {
+        id: 'act_l3',
+        type: 'action',
+        position: { x: 600, y: 300 },
+        data: { service: 'light.turn_on', target: { entity_id: 'light.three' } },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'trigger_0', target: 'act_scene_create' },
+      { id: 'e1', source: 'trigger_1', target: 'act_scene_create' },
+      { id: 'e2', source: 'act_scene_create', target: 'act_l1' },
+      { id: 'e3', source: 'act_scene_create', target: 'act_l2' },
+      { id: 'e4', source: 'act_scene_create', target: 'act_l3' },
+    ],
+  };
+
+  it('emits every downstream branch, not just the first', () => {
+    const { yaml, output } = new FlowTranspiler().transpile(flow, {
+      forceStrategy: 'state-machine',
+    });
+
+    expect(output?.strategy).toBe('state-machine');
+    // All three lights must survive generation
+    expect(yaml).toContain('light.one');
+    expect(yaml).toContain('light.two');
+    expect(yaml).toContain('light.three');
+    // and they must be fanned out, not chained
+    expect(yaml).toContain('parallel:');
+  });
+
+  it('round-trips all three fan-out edges back into the graph', async () => {
+    const { yaml } = new FlowTranspiler().transpile(flow, { forceStrategy: 'state-machine' });
+    if (!yaml) throw new Error('expected generated yaml');
+    const result = await new YamlParser().parse(yaml);
+
+    expect(result.success).toBe(true);
+    const graph = result.graph;
+    if (!graph) throw new Error('expected a parsed flow');
+
+    const fanOutTargets = graph.edges
+      .filter((e) => e.source === 'act_scene_create')
+      .map((e) => e.target)
+      .sort();
+
+    expect(fanOutTargets).toEqual(['act_l1', 'act_l2', 'act_l3']);
+
+    // Each branch node comes back as a real action node
+    for (const id of ['act_l1', 'act_l2', 'act_l3']) {
+      const node = graph.nodes.find((n) => n.id === id);
+      expect(node, `expected node ${id}`).toBeDefined();
+      expect(node?.type).toBe('action');
+    }
+  });
+
+  it('does not emit branch nodes twice as standalone state entries', () => {
+    const { yaml } = new FlowTranspiler().transpile(flow, { forceStrategy: 'state-machine' });
+
+    // Each inlined branch node appears once, inside the parallel block, and not
+    // also as its own dispatcher entry. Note YAML escapes the inner quotes, so
+    // the dispatcher form is `current_node == \\"act_l1\\"`.
+    for (const id of ['act_l1', 'act_l2', 'act_l3']) {
+      expect(yaml).toContain(`parallel_branch:${id}`);
+      expect(yaml).not.toContain(`current_node == \\"${id}\\"`);
+    }
+    // The fan-out source itself still has a dispatcher entry
+    expect(yaml).toContain('current_node == \\"act_scene_create\\"');
+  });
+
+  it('leaves condition branches alone instead of treating them as fan-out', async () => {
+    // A condition's two outgoing edges are branches, not parallel fan-out, so
+    // both targets must keep their own dispatcher entries.
+    const branching: FlowGraph = {
+      id: '44444444-5555-4666-8777-888888888888',
+      version: 1,
+      name: 'Condition branches',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'cond_1',
+          type: 'condition',
+          position: { x: 300, y: 100 },
+          data: { condition: 'state', entity_id: 'binary_sensor.c', state: 'on' },
+        },
+        {
+          id: 'act_true',
+          type: 'action',
+          position: { x: 600, y: 0 },
+          data: { service: 'light.turn_on' },
+        },
+        {
+          id: 'act_false',
+          type: 'action',
+          position: { x: 600, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'cond_1' },
+        { id: 'e1', source: 'trigger_1', target: 'cond_1' },
+        { id: 'e2', source: 'cond_1', target: 'act_true', sourceHandle: 'true' },
+        { id: 'e3', source: 'cond_1', target: 'act_false', sourceHandle: 'false' },
+      ],
+    };
+
+    const { yaml } = new FlowTranspiler().transpile(branching, {
+      forceStrategy: 'state-machine',
+    });
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // Both branch targets keep standalone dispatcher entries and are not
+    // swallowed into a parallel block.
+    expect(yaml).toContain('current_node == \\"act_true\\"');
+    expect(yaml).toContain('current_node == \\"act_false\\"');
+    expect(yaml).not.toContain('parallel:');
+
+    const result = await new YamlParser().parse(yaml);
+    const trueEdge = result.graph?.edges.find(
+      (e) => e.source === 'cond_1' && e.sourceHandle === 'true'
+    );
+    const falseEdge = result.graph?.edges.find(
+      (e) => e.source === 'cond_1' && e.sourceHandle === 'false'
+    );
+    expect(trueEdge?.target).toBe('act_true');
+    expect(falseEdge?.target).toBe('act_false');
+  });
+
+  it('warns when parallel branches re-join instead of silently duplicating work', () => {
+    const joining: FlowGraph = {
+      ...flow,
+      nodes: [
+        ...flow.nodes,
+        {
+          id: 'act_join',
+          type: 'action',
+          position: { x: 900, y: 150 },
+          data: { service: 'notify.persistent_notification' },
+        },
+      ],
+      edges: [
+        ...flow.edges,
+        { id: 'e5', source: 'act_l1', target: 'act_join' },
+        { id: 'e6', source: 'act_l2', target: 'act_join' },
+      ],
+    };
+
+    const { warnings } = new FlowTranspiler().transpile(joining, {
+      forceStrategy: 'state-machine',
+    });
+
+    expect(warnings.some((w) => w.includes('act_join'))).toBe(true);
+  });
+});
+
+describe('Issue #212 - set_variables nodes are lost on re-import', () => {
+  const flow: FlowGraph = {
+    id: '22222222-3333-4444-8555-666666666666',
+    version: 1,
+    name: 'Set variables then act',
+    nodes: [
+      ...TRIGGERS,
+      {
+        id: 'set_vars_1',
+        type: 'set_variables',
+        position: { x: 300, y: 100 },
+        data: {
+          alias: 'Extract spoken text',
+          variables: { s: '{{ trigger.event.data.text.lower() }}' },
+        },
+      },
+      {
+        id: 'act_light',
+        type: 'action',
+        position: { x: 600, y: 100 },
+        data: { service: 'light.turn_on' },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'trigger_0', target: 'set_vars_1' },
+      { id: 'e1', source: 'trigger_1', target: 'set_vars_1' },
+      { id: 'e2', source: 'set_vars_1', target: 'act_light' },
+    ],
+  };
+
+  it('round-trips a set_variables node as set_variables, not an empty action', async () => {
+    const { yaml, output } = new FlowTranspiler().transpile(flow, {
+      forceStrategy: 'state-machine',
+    });
+    expect(output?.strategy).toBe('state-machine');
+    if (!yaml) throw new Error('expected generated yaml');
+
+    const result = await new YamlParser().parse(yaml);
+    expect(result.success).toBe(true);
+
+    const node = result.graph?.nodes.find((n) => n.id === 'set_vars_1');
+    // Before the fix this came back as an `action` node with empty data
+    if (node?.type !== 'set_variables') {
+      throw new Error(`expected a set_variables node, got ${node?.type ?? 'nothing'}`);
+    }
+    expect(node.data.variables).toEqual({ s: '{{ trigger.event.data.text.lower() }}' });
+    expect(node.data.alias).toBe('Extract spoken text');
+  });
+
+  it('keeps the transition out of the set_variables node', async () => {
+    const { yaml } = new FlowTranspiler().transpile(flow, { forceStrategy: 'state-machine' });
+    if (!yaml) throw new Error('expected generated yaml');
+    const result = await new YamlParser().parse(yaml);
+
+    const outgoing = result.graph?.edges.filter((e) => e.source === 'set_vars_1') ?? [];
+    expect(outgoing.map((e) => e.target)).toEqual(['act_light']);
+  });
+
+  it('round-trips a set_variables node inlined inside a parallel branch', async () => {
+    const parallelFlow: FlowGraph = {
+      id: '33333333-4444-4555-8666-777777777777',
+      version: 1,
+      name: 'Parallel with set variables',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'set_vars_branch',
+          type: 'set_variables',
+          position: { x: 400, y: 0 },
+          data: { variables: { mode: 'night' } },
+        },
+        {
+          id: 'act_other',
+          type: 'action',
+          position: { x: 400, y: 200 },
+          data: { service: 'switch.turn_on' },
+        },
+      ],
+      // trigger_0 fans out to both, forcing them to be inlined in a parallel block
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'set_vars_branch' },
+        { id: 'e1', source: 'trigger_0', target: 'act_other' },
+        { id: 'e2', source: 'trigger_1', target: 'act_other' },
+      ],
+    };
+
+    const { yaml } = new FlowTranspiler().transpile(parallelFlow, {
+      forceStrategy: 'state-machine',
+    });
+    if (!yaml) throw new Error('expected generated yaml');
+    const result = await new YamlParser().parse(yaml);
+
+    const node = result.graph?.nodes.find((n) => n.id === 'set_vars_branch');
+    if (node?.type !== 'set_variables') {
+      throw new Error(`expected a set_variables node, got ${node?.type ?? 'nothing'}`);
+    }
+    expect(node.data.variables).toEqual({ mode: 'night' });
+  });
+});
+
+/**
+ * The fan-out rewrite removes a node's standalone dispatcher entry when it is
+ * inlined into a parallel branch. These cases guard the situations where doing
+ * so would break a previously working automation.
+ */
+describe('fan-out safety: never delete a dispatcher entry something still jumps to', () => {
+  const transpile = (flow: FlowGraph) =>
+    new FlowTranspiler().transpile(flow, { forceStrategy: 'state-machine' });
+
+  it('does not empty the choose block when a branch loops back to the fan-out source', async () => {
+    // A → B, A → C, B → A. Naive reachability marks A itself as consumed.
+    const flow: FlowGraph = {
+      id: '55555555-6666-4777-8888-999999999999',
+      version: 1,
+      name: 'Back edge into fan-out source',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'A',
+          type: 'action',
+          position: { x: 300, y: 100 },
+          data: { service: 'light.turn_on' },
+        },
+        {
+          id: 'B',
+          type: 'action',
+          position: { x: 600, y: 0 },
+          data: { service: 'switch.turn_on' },
+        },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 200 },
+          data: { service: 'switch.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'A' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+        { id: 'e4', source: 'B', target: 'A' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // Every node keeps a dispatcher entry — the choose block must not be empty
+    for (const id of ['A', 'B', 'C']) {
+      expect(yaml).toContain(`current_node == \\"${id}\\"`);
+    }
+    expect(yaml).not.toContain('choose: []');
+
+    // and the YAML must still re-import cleanly
+    const result = await new YamlParser().parse(yaml);
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+
+  it('keeps a branch node reachable from another trigger addressable', async () => {
+    // trigger_1 routes straight to B while A also fans out to B.
+    const flow: FlowGraph = {
+      id: '66666666-7777-4888-8999-aaaaaaaaaaaa',
+      version: 1,
+      name: 'Shared branch target',
+      nodes: [
+        ...TRIGGERS,
+        { id: 'A', type: 'action', position: { x: 300, y: 0 }, data: { service: 'scene.create' } },
+        { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'B' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+      ],
+    };
+
+    const { yaml, warnings } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // B is still routed to by trigger_1, so it must keep its own entry
+    expect(yaml).toContain('current_node == \\"B\\"');
+    // and the user is told why the fan-out could not be parallelized
+    expect(warnings.some((w) => w.includes('A'))).toBe(true);
+
+    const result = await new YamlParser().parse(yaml);
+    expect(result.success).toBe(true);
+  });
+
+  it('keeps a branch node reachable from an unrelated predecessor addressable', async () => {
+    const flow: FlowGraph = {
+      id: '77777777-8888-4999-8aaa-bbbbbbbbbbbb',
+      version: 1,
+      name: 'Shared branch target via node',
+      nodes: [
+        ...TRIGGERS,
+        { id: 'A', type: 'action', position: { x: 300, y: 0 }, data: { service: 'scene.create' } },
+        { id: 'D', type: 'action', position: { x: 300, y: 300 }, data: { service: 'scene.apply' } },
+        { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'D' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+        { id: 'e4', source: 'D', target: 'B' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // D transitions to B, so B must remain dispatchable
+    expect(yaml).toContain('current_node == \\"B\\"');
+
+    const result = await new YamlParser().parse(yaml);
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.success).toBe(true);
+  });
+
+  it('round-trips a nested fan-out inside a parallel branch', async () => {
+    // A → B, A → C ; B → D, B → E  (fan-out nested inside a branch)
+    const flow: FlowGraph = {
+      id: '88888888-9999-4aaa-8bbb-cccccccccccc',
+      version: 1,
+      name: 'Nested fan-out',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'A',
+          type: 'action',
+          position: { x: 300, y: 100 },
+          data: { service: 'scene.create' },
+        },
+        { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 300 },
+          data: { service: 'light.turn_off' },
+        },
+        {
+          id: 'D',
+          type: 'action',
+          position: { x: 900, y: -100 },
+          data: { service: 'switch.turn_on' },
+        },
+        {
+          id: 'E',
+          type: 'action',
+          position: { x: 900, y: 100 },
+          data: { service: 'switch.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'A' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+        { id: 'e4', source: 'B', target: 'D' },
+        { id: 'e5', source: 'B', target: 'E' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    const result = await new YamlParser().parse(yaml);
+    // Previously the nested parallel produced a dangling synthetic node id
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.success).toBe(true);
+
+    for (const id of ['A', 'B', 'C', 'D', 'E']) {
+      expect(
+        result.graph?.nodes.find((n) => n.id === id),
+        `node ${id}`
+      ).toBeDefined();
+    }
+
+    const nested = (result.graph?.edges ?? [])
+      .filter((e) => e.source === 'B')
+      .map((e) => e.target)
+      .sort();
+    expect(nested).toEqual(['D', 'E']);
+  });
+
+  it('preserves a user alias on a single-action parallel branch', async () => {
+    const flow: FlowGraph = {
+      id: '99999999-aaaa-4bbb-8ccc-dddddddddddd',
+      version: 1,
+      name: 'Aliased branch',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'A',
+          type: 'action',
+          position: { x: 300, y: 100 },
+          data: { service: 'scene.create' },
+        },
+        {
+          id: 'B',
+          type: 'action',
+          position: { x: 600, y: 0 },
+          data: { service: 'light.turn_on', alias: 'Kitchen lights' },
+        },
+        {
+          id: 'C',
+          type: 'action',
+          position: { x: 600, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'A' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'C' },
+      ],
+    };
+
+    const { yaml } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+    const result = await new YamlParser().parse(yaml);
+
+    const b = result.graph?.nodes.find((n) => n.id === 'B');
+    expect(b?.data.alias).toBe('Kitchen lights');
+  });
+
+  it('treats duplicate edges to the same target as a single branch', () => {
+    const flow: FlowGraph = {
+      id: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+      version: 1,
+      name: 'Duplicate edges',
+      nodes: [
+        ...TRIGGERS,
+        {
+          id: 'A',
+          type: 'action',
+          position: { x: 300, y: 100 },
+          data: { service: 'scene.create' },
+        },
+        { id: 'B', type: 'action', position: { x: 600, y: 0 }, data: { service: 'light.turn_on' } },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'A' },
+        { id: 'e1', source: 'trigger_1', target: 'A' },
+        { id: 'e2', source: 'A', target: 'B' },
+        { id: 'e3', source: 'A', target: 'B' },
+      ],
+    };
+
+    const { yaml, warnings } = transpile(flow);
+    if (!yaml) throw new Error('expected generated yaml');
+
+    // One duplicated target is not a fan-out — B must run once
+    expect(yaml.match(/parallel_branch:B/g) ?? []).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('reachable from more than one parallel branch'))).toBe(
+      false
+    );
+  });
+
+  it('warns about duplicate execution when trigger-level branches re-join', () => {
+    // trigger_0 → X and Y, both leading to Z: Z is inlined in both branches
+    const flow: FlowGraph = {
+      id: 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff',
+      version: 1,
+      name: 'Trigger parallel join',
+      nodes: [
+        ...TRIGGERS,
+        { id: 'X', type: 'action', position: { x: 300, y: 0 }, data: { service: 'light.turn_on' } },
+        {
+          id: 'Y',
+          type: 'action',
+          position: { x: 300, y: 200 },
+          data: { service: 'light.turn_off' },
+        },
+        {
+          id: 'Z',
+          type: 'action',
+          position: { x: 600, y: 100 },
+          data: { service: 'notify.notify' },
+        },
+      ],
+      edges: [
+        { id: 'e0', source: 'trigger_0', target: 'X' },
+        { id: 'e1', source: 'trigger_0', target: 'Y' },
+        { id: 'e2', source: 'trigger_1', target: 'X' },
+        { id: 'e3', source: 'X', target: 'Z' },
+        { id: 'e4', source: 'Y', target: 'Z' },
+      ],
+    };
+
+    const { warnings } = transpile(flow);
+    expect(warnings.some((w) => w.includes('Z'))).toBe(true);
+  });
+});

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -263,7 +263,7 @@ function isEventAction(action: unknown): action is Record<string, unknown> {
  */
 interface StateMachineNodeInfo {
   nodeId: string;
-  nodeType: 'action' | 'condition' | 'delay' | 'wait';
+  nodeType: 'action' | 'condition' | 'delay' | 'wait' | 'set_variables';
   data: Record<string, unknown>;
   trueTarget: string | null;
   falseTarget: string | null;
@@ -711,6 +711,8 @@ export class YamlParser {
       nodeInfoMap.delete(nodeId);
     }
 
+    const parallelFanOutTargets = this.resolveParallelFanOuts(nodeInfoMap);
+
     // In state-machine strategy, action/condition/delay/wait node IDs are extracted
     // directly from the Jinja2 templates in the YAML choose blocks. Only trigger
     // node IDs need to be allocated via getNextNodeId, so we filter out IDs that
@@ -778,6 +780,14 @@ export class YamlParser {
             data: info.data as WaitNode['data'],
           });
           break;
+        case 'set_variables':
+          nodes.push({
+            id: nodeId,
+            type: 'set_variables',
+            position: { x: 0, y: 0 },
+            data: info.data as SetVariablesNode['data'],
+          });
+          break;
       }
     }
 
@@ -829,6 +839,11 @@ export class YamlParser {
           sourceHandle: 'false',
         });
       }
+
+      // Fan-out: one edge per inlined parallel branch
+      for (const target of parallelFanOutTargets.get(nodeId) ?? []) {
+        edges.push(this.createEdge(nodeId, target));
+      }
     }
 
     return { nodes, edges };
@@ -871,6 +886,41 @@ export class YamlParser {
     }
 
     return routing.size > 0 ? routing : null;
+  }
+
+  /**
+   * Resolve parallel fan-out on regular nodes. When a node has more than one
+   * outgoing edge the transpiler emits its downstream branches inline inside a
+   * parallel block, so expand those back into direct node→target edges.
+   *
+   * Repeats to a fixpoint because a branch may itself contain a nested fan-out,
+   * which only becomes visible once that branch has been parsed.
+   */
+  private resolveParallelFanOuts(
+    nodeInfoMap: Map<string, StateMachineNodeInfo>
+  ): Map<string, string[]> {
+    const fanOutTargets = new Map<string, string[]>();
+    const resolved = new Set<string>();
+
+    let foundMore = true;
+    while (foundMore) {
+      foundMore = false;
+      // Snapshot: parseInlineParallelBranches inserts nodes into nodeInfoMap as it goes
+      for (const [nodeId, info] of [...nodeInfoMap]) {
+        if (!info.parallelItems || info.parallelItems.length === 0) continue;
+        if (resolved.has(nodeId)) continue;
+
+        resolved.add(nodeId);
+        foundMore = true;
+
+        const targetIds = this.parseInlineParallelBranches(info.parallelItems, nodeInfoMap);
+        if (targetIds.length > 0) {
+          fanOutTargets.set(nodeId, targetIds);
+        }
+      }
+    }
+
+    return fanOutTargets;
   }
 
   /**
@@ -942,6 +992,17 @@ export class YamlParser {
 
     for (let i = 0; i < actions.length; i++) {
       const action = actions[i];
+
+      // A bare parallel block is the previous node's fan-out, not a node of its
+      // own. Attach it so the fan-out pass can rebuild those edges.
+      if (Array.isArray(action.parallel) && action.alias === undefined) {
+        const prevInfo = prevNodeId ? nodeInfoMap.get(prevNodeId) : undefined;
+        if (prevInfo) {
+          prevInfo.parallelItems = action.parallel;
+        }
+        continue;
+      }
+
       const { nodeId: embeddedId } = this.extractCafeNodeId(action.alias as string | undefined);
       const nodeId =
         i === 0 ? firstNodeId : (embeddedId ?? generateId(this.inferInlineNodeType(action)));
@@ -1049,6 +1110,19 @@ export class YamlParser {
         trueTarget: null,
         falseTarget: null,
       });
+    } else if (item.variables !== undefined) {
+      // Set variables node
+      const data: Record<string, unknown> = { variables: item.variables };
+      if (alias) data.alias = alias;
+      if (item.id) data.id = item.id;
+
+      nodeInfoMap.set(nodeId, {
+        nodeId,
+        nodeType: 'set_variables',
+        data,
+        trueTarget: null,
+        falseTarget: null,
+      });
     }
   }
 
@@ -1075,6 +1149,7 @@ export class YamlParser {
     if (item.if) return 'condition';
     if (item.delay !== undefined) return 'delay';
     if (item.wait_template !== undefined || item.wait_for_trigger !== undefined) return 'wait';
+    if (item.variables !== undefined) return 'set_variables';
     return 'action';
   }
 
@@ -1104,7 +1179,7 @@ export class YamlParser {
     }
 
     // Parse sequence to determine node type and data
-    let nodeType: 'action' | 'condition' | 'delay' | 'wait' = 'action';
+    let nodeType: StateMachineNodeInfo['nodeType'] = 'action';
     const data: Record<string, unknown> = {};
     let trueTarget: string | null = null;
     let falseTarget: string | null = null;
@@ -1113,9 +1188,21 @@ export class YamlParser {
     for (const item of sequence) {
       const seqItem = item as Record<string, unknown>;
 
-      // Check for variables action (sets next node / edge)
+      // Check for variables action. Two distinct shapes share this key:
+      // - the state-machine transition, which always carries `current_node`
+      // - a user set_variables node, which carries arbitrary user variables
       if (seqItem.variables) {
         const vars = seqItem.variables as Record<string, unknown>;
+
+        if (!('current_node' in vars)) {
+          // User-defined variables: this block represents a set_variables node
+          nodeType = 'set_variables';
+          data.variables = vars;
+          if (seqItem.alias) data.alias = seqItem.alias;
+          if (seqItem.id) data.id = seqItem.id;
+          continue;
+        }
+
         const currentNodeValue = vars.current_node;
 
         if (typeof currentNodeValue === 'string') {

--- a/packages/transpiler/src/parser/YamlParser.ts
+++ b/packages/transpiler/src/parser/YamlParser.ts
@@ -814,9 +814,19 @@ export class YamlParser {
           }
         }
       } else {
-        // All triggers route to same node (simple case)
+        // All triggers route to same node (simple case). That node may still be
+        // a synthetic __parallel_trigger_* entry — a single trigger fanning out
+        // produces a bare id rather than a routing template — so expand it here
+        // too, otherwise the edge points at a node that no longer exists.
+        const expandedTargets = parallelTriggerTargets.get(entryNodeId);
         for (const trigger of triggerNodes) {
-          edges.push(this.createEdge(trigger.id, entryNodeId));
+          if (expandedTargets) {
+            for (const actualTarget of expandedTargets) {
+              edges.push(this.createEdge(trigger.id, actualTarget));
+            }
+          } else {
+            edges.push(this.createEdge(trigger.id, entryNodeId));
+          }
         }
       }
     }

--- a/packages/transpiler/src/strategies/state-machine.ts
+++ b/packages/transpiler/src/strategies/state-machine.ts
@@ -88,10 +88,50 @@ export class StateMachineStrategy extends BaseStrategy {
       }
     }
 
+    for (const [, targets] of triggerRouting) {
+      if (targets.length > 1) {
+        const joinWarning = this.detectParallelBranchJoin(flow, targets);
+        if (joinWarning) {
+          warnings.push(joinWarning);
+        }
+      }
+    }
+
+    // Nodes that fan out to several successors inline those successors into a
+    // parallel block, so their subgraphs are consumed the same way. This is only
+    // safe when the branches are exclusively owned by this fan-out — otherwise
+    // consuming them would delete dispatcher entries other nodes still jump to.
+    const fanOutPlans = new Map<string, string[]>();
+    for (const node of flow.nodes) {
+      // Conditions branch through their own true/false path and never build a
+      // fan-out tail, so their targets must keep their standalone entries.
+      if (node.type === 'trigger' || node.type === 'condition') continue;
+      const targets = this.getFanOutTargets(flow, node.id);
+      if (targets.length <= 1) continue;
+
+      const owned = this.planExclusiveFanOut(flow, node.id, targets, parallelConsumedNodeIds);
+      if (!owned) {
+        warnings.push(
+          `Node "${node.id}" fans out to [${targets.join(', ')}], but those branches are also reachable from elsewhere in the flow (or lead back to "${node.id}"). Parallel execution needs self-contained branches, so only the first branch will run. Give each branch its own downstream nodes to run them in parallel.`
+        );
+        continue;
+      }
+
+      fanOutPlans.set(node.id, targets);
+      for (const id of owned) {
+        parallelConsumedNodeIds.add(id);
+      }
+
+      const joinWarning = this.detectParallelBranchJoin(flow, targets);
+      if (joinWarning) {
+        warnings.push(joinWarning);
+      }
+    }
+
     // Build choose blocks for each non-trigger node not already inlined in a parallel branch
     const nodeBlocks = flow.nodes
       .filter((n) => n.type !== 'trigger' && !parallelConsumedNodeIds.has(n.id))
-      .map((node) => this.generateNodeBlock(flow, node));
+      .map((node) => this.generateNodeBlock(flow, node, fanOutPlans));
 
     // Combine parallel entry blocks and remaining node blocks
     const chooseBlocks = [...parallelEntryBlocks, ...nodeBlocks];
@@ -281,21 +321,7 @@ export class StateMachineStrategy extends BaseStrategy {
 
       const parallelEntryId = `__parallel_trigger_${idx}`;
 
-      // Build self-contained inline branches for all target nodes.
-      // Each branch gets a "parallel_branch:<nodeId>" alias so the parser
-      // can identify which node each branch corresponds to.
-      const parallelBranches = targets.map((targetId) => {
-        const inlineActions = this.generateInlineBranch(flow, targetId, new Set());
-        if (inlineActions.length === 0) {
-          return { alias: `parallel_branch:${targetId}`, stop: 'Empty branch' };
-        }
-        if (inlineActions.length === 1) {
-          // Single action — spread first, then override alias with branch identifier
-          return { ...inlineActions[0], alias: `parallel_branch:${targetId}` };
-        }
-        // Multiple actions — wrap in a sequence
-        return { alias: `parallel_branch:${targetId}`, sequence: inlineActions };
-      });
+      const parallelBranches = this.buildParallelBranches(flow, targets);
 
       parallelBlocks.push({
         conditions: [
@@ -318,6 +344,138 @@ export class StateMachineStrategy extends BaseStrategy {
     }
 
     return parallelBlocks;
+  }
+
+  /**
+   * Outgoing edges that represent parallel fan-out rather than conditional
+   * branching. Edges carrying a true/false handle belong to a condition node
+   * and are excluded.
+   */
+  private getFanOutEdges(flow: FlowGraph, nodeId: string): FlowEdge[] {
+    return this.getOutgoingEdges(flow, nodeId).filter(
+      (e) => e.sourceHandle !== 'true' && e.sourceHandle !== 'false'
+    );
+  }
+
+  /**
+   * Distinct fan-out targets for a node. Duplicate edges to the same target
+   * would otherwise produce duplicate branches that run the target twice.
+   */
+  private getFanOutTargets(flow: FlowGraph, nodeId: string): string[] {
+    return [...new Set(this.getFanOutEdges(flow, nodeId).map((e) => e.target))].filter(
+      (target) => target !== 'END' && target !== nodeId
+    );
+  }
+
+  /**
+   * Decide whether a node's fan-out branches can be safely inlined.
+   *
+   * Inlining a branch removes its nodes' standalone dispatcher entries, so it is
+   * only sound when nothing outside the branch set jumps into it. Returns the set
+   * of nodes to consume, or null when the fan-out must be left alone — for
+   * example when a branch loops back to the source, or a branch node is also
+   * reached from a trigger or from another part of the flow.
+   */
+  private planExclusiveFanOut(
+    flow: FlowGraph,
+    sourceId: string,
+    targets: string[],
+    alreadyConsumed: Set<string>
+  ): Set<string> | null {
+    const reachable = new Set<string>();
+    for (const target of targets) {
+      this.collectSubgraphNodeIds(flow, target, reachable);
+    }
+
+    // A branch that loops back to the source would delete the source's own entry
+    if (reachable.has(sourceId)) return null;
+
+    for (const id of reachable) {
+      // Another fan-out already owns this node; inlining it twice would duplicate it
+      if (alreadyConsumed.has(id)) return null;
+
+      for (const edge of flow.edges) {
+        if (edge.target !== id) continue;
+        // Every way into a consumed node must come from the fan-out itself
+        if (edge.source !== sourceId && !reachable.has(edge.source)) return null;
+      }
+    }
+
+    return reachable;
+  }
+
+  /**
+   * Parallel branches are inlined independently, so a node reachable from more
+   * than one branch is emitted — and therefore executed — once per branch.
+   * Warn rather than silently duplicating it.
+   */
+  private detectParallelBranchJoin(flow: FlowGraph, targets: string[]): string | null {
+    const seen = new Set<string>();
+    const duplicated = new Set<string>();
+
+    for (const target of targets) {
+      const branchNodes = new Set<string>();
+      this.collectSubgraphNodeIds(flow, target, branchNodes);
+      for (const id of branchNodes) {
+        if (seen.has(id)) {
+          duplicated.add(id);
+        }
+        seen.add(id);
+      }
+    }
+
+    if (duplicated.size === 0) return null;
+
+    return `Nodes [${[...duplicated].join(', ')}] are reachable from more than one parallel branch and will run once per branch. Parallel branches cannot re-join in the state-machine strategy.`;
+  }
+
+  /**
+   * Build self-contained inline branches for a set of target nodes.
+   * Each branch gets a "parallel_branch:<nodeId>" alias so the parser can
+   * identify which node each branch corresponds to on the way back in.
+   */
+  private buildParallelBranches(
+    flow: FlowGraph,
+    targets: string[],
+    visited: Set<string> = new Set()
+  ): Record<string, unknown>[] {
+    return targets.map((targetId) => {
+      // Each branch gets its own visited copy so sibling branches don't block each other
+      const inlineActions = this.generateInlineBranch(flow, targetId, new Set(visited));
+      if (inlineActions.length === 0) {
+        return { alias: `parallel_branch:${targetId}`, stop: 'Empty branch' };
+      }
+      // Always wrap in a sequence. Spreading a single action and overwriting its
+      // alias would destroy the "cafe_node:<id>:<userAlias>" encoding and lose
+      // the node's user-facing alias on the way back in.
+      return { alias: `parallel_branch:${targetId}`, sequence: inlineActions };
+    });
+  }
+
+  /**
+   * Build the tail of a node's state-machine sequence.
+   * A single outgoing edge advances current_node to the next node; multiple
+   * outgoing edges fan out into a parallel block of self-contained branches
+   * and then end the flow, since all downstream work happens inside them.
+   */
+  private buildTransitionTail(
+    flow: FlowGraph,
+    nodeId: string,
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown>[] {
+    // Only fan out when the branches were verified as exclusively owned by this
+    // node; otherwise fall through to the sequential transition below.
+    const approvedTargets = fanOutPlans.get(nodeId);
+
+    if (approvedTargets && approvedTargets.length > 1) {
+      return [
+        { parallel: this.buildParallelBranches(flow, approvedTargets) },
+        { variables: { current_node: 'END' } },
+      ];
+    }
+
+    return [{ variables: { current_node: edges[0]?.target ?? 'END' } }];
   }
 
   /**
@@ -351,6 +509,35 @@ export class StateMachineStrategy extends BaseStrategy {
    * Used within parallel branches where each branch must be self-contained
    * (no current_node state machine variable).
    */
+  /**
+   * Continue an inline branch past the current node. A single successor is
+   * appended sequentially; several successors fan out into a nested parallel
+   * block so none of them are dropped.
+   */
+  private continueInlineBranch(
+    flow: FlowGraph,
+    edges: FlowEdge[],
+    visited: Set<string>
+  ): Record<string, unknown>[] {
+    const fanOutEdges = edges.filter(
+      (e) => e.sourceHandle !== 'true' && e.sourceHandle !== 'false'
+    );
+
+    if (fanOutEdges.length > 1) {
+      return [
+        {
+          parallel: this.buildParallelBranches(
+            flow,
+            fanOutEdges.map((e) => e.target),
+            visited
+          ),
+        },
+      ];
+    }
+
+    return this.generateInlineBranch(flow, edges[0]?.target ?? 'END', visited);
+  }
+
   private generateInlineBranch(
     flow: FlowGraph,
     nodeId: string,
@@ -370,8 +557,7 @@ export class StateMachineStrategy extends BaseStrategy {
       case 'action': {
         const actionCall = this.buildActionCall(node as ActionNode);
         this.encodeNodeIdInAlias(actionCall, node.id);
-        const nextNodeId = edges[0]?.target ?? 'END';
-        return [actionCall, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+        return [actionCall, ...this.continueInlineBranch(flow, edges, visited)];
       }
 
       case 'condition': {
@@ -400,28 +586,24 @@ export class StateMachineStrategy extends BaseStrategy {
       case 'delay': {
         const delayAction = this.buildDelayAction(node as DelayNode);
         this.encodeNodeIdInAlias(delayAction, node.id);
-        const nextNodeId = edges[0]?.target ?? 'END';
-        return [delayAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+        return [delayAction, ...this.continueInlineBranch(flow, edges, visited)];
       }
 
       case 'wait': {
         const waitAction = this.buildWaitAction(node as WaitNode);
         this.encodeNodeIdInAlias(waitAction, node.id);
-        const nextNodeId = edges[0]?.target ?? 'END';
-        return [waitAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+        return [waitAction, ...this.continueInlineBranch(flow, edges, visited)];
       }
 
       case 'set_variables': {
         const setVarsAction = this.buildSetVariablesAction(node as SetVariablesNode);
         this.encodeNodeIdInAlias(setVarsAction, node.id);
-        const nextNodeId = edges[0]?.target ?? 'END';
-        return [setVarsAction, ...this.generateInlineBranch(flow, nextNodeId, visited)];
+        return [setVarsAction, ...this.continueInlineBranch(flow, edges, visited)];
       }
 
       default: {
         // Unknown node type — skip it and continue to the next node
-        const nextNodeId = edges[0]?.target ?? 'END';
-        return this.generateInlineBranch(flow, nextNodeId, visited);
+        return this.continueInlineBranch(flow, edges, visited);
       }
     }
   }
@@ -444,22 +626,26 @@ export class StateMachineStrategy extends BaseStrategy {
   /**
    * Generate a choose block for a single node
    */
-  private generateNodeBlock(flow: FlowGraph, node: FlowNode): Record<string, unknown> {
+  private generateNodeBlock(
+    flow: FlowGraph,
+    node: FlowNode,
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown> {
     const outgoingEdges = this.getOutgoingEdges(flow, node.id);
 
     switch (node.type) {
       case 'condition':
         return this.generateConditionBlock(node, outgoingEdges);
       case 'action':
-        return this.generateActionBlock(node, outgoingEdges);
+        return this.generateActionBlock(flow, node, outgoingEdges, fanOutPlans);
       case 'delay':
-        return this.generateDelayBlock(node, outgoingEdges);
+        return this.generateDelayBlock(flow, node, outgoingEdges, fanOutPlans);
       case 'wait':
-        return this.generateWaitBlock(node, outgoingEdges);
+        return this.generateWaitBlock(flow, node, outgoingEdges, fanOutPlans);
       case 'set_variables':
-        return this.generateSetVariablesBlock(node, outgoingEdges);
+        return this.generateSetVariablesBlock(flow, node, outgoingEdges, fanOutPlans);
       default:
-        return this.generatePassthroughBlock(node, outgoingEdges);
+        return this.generatePassthroughBlock(flow, node, outgoingEdges, fanOutPlans);
     }
   }
 
@@ -467,13 +653,14 @@ export class StateMachineStrategy extends BaseStrategy {
    * Generate block for action node
    * Executes the service call then moves to the next node
    */
-  private generateActionBlock(node: ActionNode, edges: FlowEdge[]): Record<string, unknown> {
+  private generateActionBlock(
+    flow: FlowGraph,
+    node: ActionNode,
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown> {
     const currentNodeId = node.id;
     const actionCall = this.buildActionCall(node);
-
-    // Single outgoing edge - standard behavior
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
 
     return {
       conditions: [
@@ -482,14 +669,7 @@ export class StateMachineStrategy extends BaseStrategy {
           value_template: `{{ current_node == "${currentNodeId}" }}`,
         },
       ],
-      sequence: [
-        actionCall,
-        {
-          variables: {
-            current_node: nextNode,
-          },
-        },
-      ],
+      sequence: [actionCall, ...this.buildTransitionTail(flow, node.id, edges, fanOutPlans)],
     };
   }
 
@@ -791,9 +971,12 @@ export class StateMachineStrategy extends BaseStrategy {
   /**
    * Generate block for delay node
    */
-  private generateDelayBlock(node: DelayNode, edges: FlowEdge[]): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+  private generateDelayBlock(
+    flow: FlowGraph,
+    node: DelayNode,
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown> {
     const currentNodeId = node.id;
 
     return {
@@ -805,11 +988,7 @@ export class StateMachineStrategy extends BaseStrategy {
       ],
       sequence: [
         this.buildDelayAction(node),
-        {
-          variables: {
-            current_node: nextNode,
-          },
-        },
+        ...this.buildTransitionTail(flow, node.id, edges, fanOutPlans),
       ],
     };
   }
@@ -863,9 +1042,12 @@ export class StateMachineStrategy extends BaseStrategy {
   /**
    * Generate block for wait node
    */
-  private generateWaitBlock(node: WaitNode, edges: FlowEdge[]): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+  private generateWaitBlock(
+    flow: FlowGraph,
+    node: WaitNode,
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown> {
     const currentNodeId = node.id;
 
     return {
@@ -877,11 +1059,7 @@ export class StateMachineStrategy extends BaseStrategy {
       ],
       sequence: [
         this.buildWaitAction(node),
-        {
-          variables: {
-            current_node: nextNode,
-          },
-        },
+        ...this.buildTransitionTail(flow, node.id, edges, fanOutPlans),
       ],
     };
   }
@@ -912,11 +1090,11 @@ export class StateMachineStrategy extends BaseStrategy {
    * Generate block for set_variables node
    */
   private generateSetVariablesBlock(
+    flow: FlowGraph,
     node: SetVariablesNode,
-    edges: FlowEdge[]
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
   ): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
     const currentNodeId = node.id;
 
     return {
@@ -928,11 +1106,7 @@ export class StateMachineStrategy extends BaseStrategy {
       ],
       sequence: [
         this.buildSetVariablesAction(node),
-        {
-          variables: {
-            current_node: nextNode,
-          },
-        },
+        ...this.buildTransitionTail(flow, node.id, edges, fanOutPlans),
       ],
     };
   }
@@ -940,9 +1114,12 @@ export class StateMachineStrategy extends BaseStrategy {
   /**
    * Generate passthrough block for unknown node types
    */
-  private generatePassthroughBlock(node: FlowNode, edges: FlowEdge[]): Record<string, unknown> {
-    const nextNodeId = edges[0]?.target ?? 'END';
-    const nextNode = nextNodeId === 'END' ? 'END' : nextNodeId;
+  private generatePassthroughBlock(
+    flow: FlowGraph,
+    node: FlowNode,
+    edges: FlowEdge[],
+    fanOutPlans: Map<string, string[]>
+  ): Record<string, unknown> {
     const currentNodeId = node.id;
 
     return {
@@ -952,13 +1129,7 @@ export class StateMachineStrategy extends BaseStrategy {
           value_template: `{{ current_node == "${currentNodeId}" }}`,
         },
       ],
-      sequence: [
-        {
-          variables: {
-            current_node: nextNode,
-          },
-        },
-      ],
+      sequence: this.buildTransitionTail(flow, node.id, edges, fanOutPlans),
     };
   }
 

--- a/packages/transpiler/src/strategies/state-machine.ts
+++ b/packages/transpiler/src/strategies/state-machine.ts
@@ -101,11 +101,20 @@ export class StateMachineStrategy extends BaseStrategy {
     // parallel block, so their subgraphs are consumed the same way. This is only
     // safe when the branches are exclusively owned by this fan-out — otherwise
     // consuming them would delete dispatcher entries other nodes still jump to.
+    // Walk outward from the entry points so an outer fan-out always claims its
+    // subgraph before any nested one does. Iterating flow.nodes in array order
+    // would let a nested node claim first, which strands the outer node's other
+    // branches and drops their edges.
     const fanOutPlans = new Map<string, string[]>();
-    for (const node of flow.nodes) {
+    for (const node of this.orderNodesFromEntry(flow)) {
       // Conditions branch through their own true/false path and never build a
       // fan-out tail, so their targets must keep their standalone entries.
       if (node.type === 'trigger' || node.type === 'condition') continue;
+
+      // Already inlined into an ancestor's parallel branch. Its own fan-out is
+      // emitted by continueInlineBranch, so there is nothing to plan or warn about.
+      if (parallelConsumedNodeIds.has(node.id)) continue;
+
       const targets = this.getFanOutTargets(flow, node.id);
       if (targets.length <= 1) continue;
 
@@ -122,9 +131,15 @@ export class StateMachineStrategy extends BaseStrategy {
         parallelConsumedNodeIds.add(id);
       }
 
-      const joinWarning = this.detectParallelBranchJoin(flow, targets);
-      if (joinWarning) {
-        warnings.push(joinWarning);
+      // Report joins for this fan-out and for every nested fan-out inside it,
+      // since those nodes are inlined and never planned on their own.
+      for (const branchNodeId of [node.id, ...owned]) {
+        const branchTargets = this.getFanOutTargets(flow, branchNodeId);
+        if (branchTargets.length <= 1) continue;
+        const joinWarning = this.detectParallelBranchJoin(flow, branchTargets);
+        if (joinWarning) {
+          warnings.push(joinWarning);
+        }
       }
     }
 
@@ -321,7 +336,7 @@ export class StateMachineStrategy extends BaseStrategy {
 
       const parallelEntryId = `__parallel_trigger_${idx}`;
 
-      const parallelBranches = this.buildParallelBranches(flow, targets);
+      const parallelBranches = this.buildParallelBranches(flow, [...new Set(targets)]);
 
       parallelBlocks.push({
         conditions: [
@@ -355,6 +370,47 @@ export class StateMachineStrategy extends BaseStrategy {
     return this.getOutgoingEdges(flow, nodeId).filter(
       (e) => e.sourceHandle !== 'true' && e.sourceHandle !== 'false'
     );
+  }
+
+  /**
+   * Nodes ordered by distance from the trigger entry points (breadth-first),
+   * with any unreachable nodes appended in declaration order.
+   *
+   * Fan-out planning must be deterministic and outermost-first: whichever node
+   * claims a subgraph first owns it, so processing a nested node before its
+   * ancestor would strand the ancestor's remaining branches.
+   */
+  private orderNodesFromEntry(flow: FlowGraph): FlowNode[] {
+    const byId = new Map(flow.nodes.map((n) => [n.id, n]));
+    const ordered: FlowNode[] = [];
+    const seen = new Set<string>();
+
+    const queue = flow.nodes
+      .filter((n) => n.type === 'trigger')
+      .flatMap((trigger) => this.getOutgoingEdges(flow, trigger.id).map((e) => e.target));
+
+    while (queue.length > 0) {
+      const nodeId = queue.shift();
+      if (nodeId === undefined || nodeId === 'END' || seen.has(nodeId)) continue;
+      seen.add(nodeId);
+
+      const node = byId.get(nodeId);
+      if (!node) continue;
+      ordered.push(node);
+
+      for (const edge of this.getOutgoingEdges(flow, nodeId)) {
+        queue.push(edge.target);
+      }
+    }
+
+    // Nodes not reachable from any trigger still need blocks generated
+    for (const node of flow.nodes) {
+      if (node.type !== 'trigger' && !seen.has(node.id)) {
+        ordered.push(node);
+      }
+    }
+
+    return ordered;
   }
 
   /**
@@ -516,26 +572,19 @@ export class StateMachineStrategy extends BaseStrategy {
    */
   private continueInlineBranch(
     flow: FlowGraph,
+    nodeId: string,
     edges: FlowEdge[],
     visited: Set<string>
   ): Record<string, unknown>[] {
-    const fanOutEdges = edges.filter(
-      (e) => e.sourceHandle !== 'true' && e.sourceHandle !== 'false'
-    );
+    // Same de-duping as the top-level path, so duplicate edges to one target
+    // don't produce duplicate branches that run it twice.
+    const targets = this.getFanOutTargets(flow, nodeId);
 
-    if (fanOutEdges.length > 1) {
-      return [
-        {
-          parallel: this.buildParallelBranches(
-            flow,
-            fanOutEdges.map((e) => e.target),
-            visited
-          ),
-        },
-      ];
+    if (targets.length > 1) {
+      return [{ parallel: this.buildParallelBranches(flow, targets, visited) }];
     }
 
-    return this.generateInlineBranch(flow, edges[0]?.target ?? 'END', visited);
+    return this.generateInlineBranch(flow, targets[0] ?? edges[0]?.target ?? 'END', visited);
   }
 
   private generateInlineBranch(
@@ -557,7 +606,7 @@ export class StateMachineStrategy extends BaseStrategy {
       case 'action': {
         const actionCall = this.buildActionCall(node as ActionNode);
         this.encodeNodeIdInAlias(actionCall, node.id);
-        return [actionCall, ...this.continueInlineBranch(flow, edges, visited)];
+        return [actionCall, ...this.continueInlineBranch(flow, node.id, edges, visited)];
       }
 
       case 'condition': {
@@ -586,24 +635,24 @@ export class StateMachineStrategy extends BaseStrategy {
       case 'delay': {
         const delayAction = this.buildDelayAction(node as DelayNode);
         this.encodeNodeIdInAlias(delayAction, node.id);
-        return [delayAction, ...this.continueInlineBranch(flow, edges, visited)];
+        return [delayAction, ...this.continueInlineBranch(flow, node.id, edges, visited)];
       }
 
       case 'wait': {
         const waitAction = this.buildWaitAction(node as WaitNode);
         this.encodeNodeIdInAlias(waitAction, node.id);
-        return [waitAction, ...this.continueInlineBranch(flow, edges, visited)];
+        return [waitAction, ...this.continueInlineBranch(flow, node.id, edges, visited)];
       }
 
       case 'set_variables': {
         const setVarsAction = this.buildSetVariablesAction(node as SetVariablesNode);
         this.encodeNodeIdInAlias(setVarsAction, node.id);
-        return [setVarsAction, ...this.continueInlineBranch(flow, edges, visited)];
+        return [setVarsAction, ...this.continueInlineBranch(flow, node.id, edges, visited)];
       }
 
       default: {
         // Unknown node type — skip it and continue to the next node
-        return this.continueInlineBranch(flow, edges, visited);
+        return this.continueInlineBranch(flow, node.id, edges, visited);
       }
     }
   }


### PR DESCRIPTION
The state-machine strategy is selected whenever a flow has 2+ triggers, and it was lossy in both directions. #209 fixed the condition half in #236; this fixes the remaining two.

## #228 — fan-out ran only the first branch

Every block generator advanced the state machine with `edges[0]?.target ?? 'END'`, silently discarding all outgoing edges past the first. A node fanning out to three lights ran one and left the other two as orphaned, unreachable `choose` cases.

Reproduced on `main` before fixing: with **one** trigger the native strategy is chosen and correctly emits a `parallel:` block; adding a **second** trigger switches to the state machine and only `act_l1` survives. The trigger count, not `scene.create`, is what makes this appear.

Multiple successors now fan out into an HA `parallel:` block of self-contained branches.

### The part that needed care

Inlining a branch removes its nodes' dispatcher entries, so it is only sound when nothing outside the branch set jumps into it. Reachability from a branch is not the same as ownership of it. `planExclusiveFanOut()` refuses to inline when:

- a branch loops back to the fan-out source,
- a node is already claimed by another fan-out, or
- anything external (another trigger, an unrelated predecessor) routes into it.

When it refuses, the node keeps its sequential behavior and the transpiler emits a warning explaining why the branches could not be parallelized.

This guard is not theoretical. Without it, an earlier revision of this PR would have **broken working automations**: a back-edge into a fan-out source emptied the entire `choose` block — `choose: []` is schema-valid, so the automation loaded in HA and did nothing — and a branch target shared with another trigger became a dangling `current_node` reference that hit the "Unknown state" default. Both are covered by regression tests that fail if the guard is removed.

## #212 — set_variables came back as an empty action

`parseStateMachineChooseBlock` could not tell the state-machine transition from a user `set_variables` node, since both use a `variables` key. The user's variables item had no `current_node`, fell through with no `else`, and left the node as an `action` with empty data.

Verified against the reporter's attachments: `variables: {s: "{{ trigger.event.data.text.lower() }}"}` came back as a bare `service: light.turn_on`.

The two are now distinguished by the presence of `current_node`. `set_variables` is also handled in the inline-branch parser, and the parser learned to read nested `parallel` blocks so a fan-out inside a branch round-trips instead of minting a dangling synthetic node id.

## Also fixed

- Parallel branches that re-join are inlined once per branch and so execute once per branch — something the state machine cannot express otherwise. This now warns and names the affected nodes rather than duplicating work silently. The warning also covers trigger-level parallel routing, which previously had none.
- Single-action branches are wrapped in `sequence:` so the `cafe_node:<id>:<alias>` encoding survives; user aliases were being overwritten by the branch marker.
- Duplicate edges to the same target no longer produce duplicate branches.

## Known limitation

When branches are not exclusively owned, only the first still runs — the pre-existing behavior — now with an explicit warning instead of silence. Fully fixing that needs parallel branches that can re-enter the dispatcher, which the state machine has no construct for. Shipping the safe subset plus a clear warning seemed better than a partial fix that looks complete.

## Verification

- 15 new regression tests; the ones for #228/#212 were confirmed to fail on the pre-fix code with exactly the reported symptoms, and the three fan-out-safety tests fail if the exclusivity guard is neutered.
- Full gate green: `typecheck` clean, **292 tests pass**, `lint:biome` at the pre-existing baseline, `format:check` clean.
- The reporter's #228 scenario verified end to end: valid HA `parallel:` with all three lights, no warnings, clean re-import, all aliases preserved.

Fixes #228
Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018th9xwV2JcutmxtA1g4ekH