### PR TITLE
fix(frontend): don't let validation errors outlive their node (#238)

### DIFF
--- a/packages/frontend/src/store/__tests__/issue-238-stale-node-errors.test.ts
+++ b/packages/frontend/src/store/__tests__/issue-238-stale-node-errors.test.ts
@@ -1,0 +1,81 @@
+import type { Node } from '@xyflow/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type FlowNodeData, useFlowStore } from '../flow-store';
+
+/**
+ * Issue #238 — "Cannot save: N node(s) have validation errors" with nothing
+ * highlighted. `nodeErrors` is keyed by node ID, so a deleted node's errors
+ * would otherwise linger with no visible node to account for them.
+ */
+describe('Issue #238 - validation errors must not outlive their node', () => {
+  const invalidNode: Node<FlowNodeData> = {
+    id: 'set_vars_bad',
+    type: 'set_variables',
+    position: { x: 3000, y: 0 },
+    // A Set Variables node with no variables fails validation
+    data: { variables: {} },
+  };
+
+  const validNode: Node<FlowNodeData> = {
+    id: 'act_ok',
+    type: 'action',
+    position: { x: 0, y: 0 },
+    data: { service: 'light.turn_on' },
+  };
+
+  beforeEach(() => {
+    useFlowStore.getState().reset();
+  });
+
+  it('clears the error when the offending node is removed', () => {
+    const { addNode, validateAllNodes, removeNode } = useFlowStore.getState();
+    addNode(validNode);
+    addNode(invalidNode);
+    validateAllNodes();
+
+    expect(useFlowStore.getState().nodeErrors.has('set_vars_bad')).toBe(true);
+
+    removeNode('set_vars_bad');
+
+    const state = useFlowStore.getState();
+    expect(state.nodeErrors.has('set_vars_bad')).toBe(false);
+    expect(state.hasValidationErrors()).toBe(false);
+  });
+
+  it('clears the error when the node is deleted through onNodesChange', () => {
+    const { addNode, validateAllNodes, onNodesChange } = useFlowStore.getState();
+    addNode(validNode);
+    addNode(invalidNode);
+    validateAllNodes();
+    expect(useFlowStore.getState().nodeErrors.size).toBe(1);
+
+    // What pressing Delete on the canvas does
+    onNodesChange([{ type: 'remove', id: 'set_vars_bad' }]);
+
+    expect(useFlowStore.getState().nodeErrors.size).toBe(0);
+  });
+
+  it('leaves errors for nodes that still exist alone', () => {
+    const { addNode, validateAllNodes, removeNode } = useFlowStore.getState();
+    addNode(validNode);
+    addNode(invalidNode);
+    validateAllNodes();
+
+    removeNode('act_ok');
+
+    expect(useFlowStore.getState().nodeErrors.has('set_vars_bad')).toBe(true);
+  });
+
+  it('keeps the same Map instance when there is nothing to prune', () => {
+    const { addNode, validateAllNodes, onNodesChange } = useFlowStore.getState();
+    addNode(validNode);
+    addNode(invalidNode);
+    validateAllNodes();
+
+    const before = useFlowStore.getState().nodeErrors;
+    // A position change must not churn the errors map
+    onNodesChange([{ type: 'position', id: 'act_ok', position: { x: 10, y: 10 } }]);
+
+    expect(useFlowStore.getState().nodeErrors).toBe(before);
+  });
+});

--- a/packages/frontend/src/store/flow-store.ts
+++ b/packages/frontend/src/store/flow-store.ts
@@ -267,6 +267,75 @@ function normalizeNodeData(type: string, data: Record<string, unknown>): Record<
  * `validateNodeData`'s per-node schema check, which never sees the rest of the
  * graph.
  */
+/**
+ * Drop validation errors belonging to nodes that no longer exist.
+ *
+ * `nodeErrors` is keyed by node ID, so deleting a node would otherwise leave its
+ * errors behind forever: the canvas reports a non-zero error count that no
+ * visible node accounts for, and nothing can clear it because the node is gone.
+ * Returns the same Map instance when nothing changed, so subscribers don't
+ * re-render needlessly.
+ */
+function pruneNodeErrors(
+  nodeErrors: Map<string, NodeValidationError[]>,
+  nodes: Node<FlowNodeData>[]
+): Map<string, NodeValidationError[]> {
+  if (nodeErrors.size === 0) return nodeErrors;
+
+  const liveIds = new Set(nodes.map((n) => n.id));
+  const stale = [...nodeErrors.keys()].filter((id) => !liveIds.has(id));
+  if (stale.length === 0) return nodeErrors;
+
+  const pruned = new Map(nodeErrors);
+  for (const id of stale) {
+    pruned.delete(id);
+  }
+  return pruned;
+}
+
+/**
+ * A short human-readable name for a node, for error messages that need to point
+ * the user at a specific node on the canvas.
+ */
+function describeNode(node: Node<FlowNodeData>): string {
+  const data = node.data as Record<string, unknown>;
+  const candidates = [data.alias, data.service, data.event, data.trigger, data.condition];
+  const label = candidates.find((v): v is string => typeof v === 'string' && v.trim() !== '');
+  return label ? `${label} (${node.id})` : node.id;
+}
+
+/**
+ * Throw a save-blocking error naming the invalid nodes, and select the first one
+ * so the user can actually find it.
+ *
+ * "Fix the highlighted nodes" is useless on its own when the offending node sits
+ * outside the viewport — the original report for this was a flow whose two bad
+ * nodes were at x=3000 while everything else was under x=1185.
+ */
+function assertNodesAreValid(
+  nodes: Node<FlowNodeData>[],
+  nodeErrors: Map<string, NodeValidationError[]>,
+  selectNode: (nodeId: string) => void
+): void {
+  if (nodeErrors.size === 0) return;
+
+  const invalid = nodes.filter((n) => nodeErrors.has(n.id));
+  const firstInvalid = invalid[0];
+  if (firstInvalid) {
+    selectNode(firstInvalid.id);
+  }
+
+  const names = invalid.map(describeNode);
+  const shown = names.slice(0, 3).join(', ');
+  const remaining = names.length > 3 ? `, and ${names.length - 3} more` : '';
+  const named = names.length > 0 ? `: ${shown}${remaining}` : '';
+
+  throw new Error(
+    `Cannot save: ${nodeErrors.size} node(s) have validation errors${named}. ` +
+      `They are highlighted in red — the first one is now selected, and "fit view" will bring it into sight if it is off-screen.`
+  );
+}
+
 function findDuplicateIdErrors(nodes: Node<FlowNodeData>[]): Map<string, NodeValidationError> {
   const idToNodeIds = new Map<string, string[]>();
   for (const node of nodes) {
@@ -406,10 +475,16 @@ export const useFlowStore = create<FlowState>()(
         setEdges: (edges) => set({ edges }),
 
         onNodesChange: (changes) =>
-          set((state) => ({
-            nodes: applyNodeChanges(changes, state.nodes),
-            hasUnsavedChanges: true,
-          })),
+          set((state) => {
+            const nodes = applyNodeChanges(changes, state.nodes);
+            return {
+              nodes,
+              // Deleting a node here (e.g. the Delete key) must take its
+              // validation errors with it
+              nodeErrors: pruneNodeErrors(state.nodeErrors, nodes),
+              hasUnsavedChanges: true,
+            };
+          }),
 
         onEdgesChange: (changes) =>
           set((state) => ({
@@ -468,12 +543,16 @@ export const useFlowStore = create<FlowState>()(
         },
 
         removeNode: (nodeId) =>
-          set((state) => ({
-            nodes: state.nodes.filter((n) => n.id !== nodeId),
-            edges: state.edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
-            selectedNodeId: state.selectedNodeId === nodeId ? null : state.selectedNodeId,
-            hasUnsavedChanges: true,
-          })),
+          set((state) => {
+            const nodes = state.nodes.filter((n) => n.id !== nodeId);
+            return {
+              nodes,
+              edges: state.edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
+              selectedNodeId: state.selectedNodeId === nodeId ? null : state.selectedNodeId,
+              nodeErrors: pruneNodeErrors(state.nodeErrors, nodes),
+              hasUnsavedChanges: true,
+            };
+          }),
 
         // Inserts a template Condition node right after a Wait node so the user
         // can branch on `wait.trigger is not none` / `wait.completed` — i.e.
@@ -588,12 +667,9 @@ export const useFlowStore = create<FlowState>()(
 
             // Check for validation errors
             const currentState = get();
-            if (currentState.nodeErrors.size > 0) {
-              const errorCount = currentState.nodeErrors.size;
-              throw new Error(
-                `Cannot save: ${errorCount} node(s) have validation errors. Fix the highlighted nodes before saving.`
-              );
-            }
+            assertNodesAreValid(currentState.nodes, currentState.nodeErrors, (nodeId) =>
+              set({ selectedNodeId: nodeId })
+            );
 
             // Convert flow to graph
             const graph = state.toFlowGraph();
@@ -699,12 +775,9 @@ export const useFlowStore = create<FlowState>()(
 
             // Check for validation errors
             const currentState = get();
-            if (currentState.nodeErrors.size > 0) {
-              const errorCount = currentState.nodeErrors.size;
-              throw new Error(
-                `Cannot save: ${errorCount} node(s) have validation errors. Fix the highlighted nodes before saving.`
-              );
-            }
+            assertNodesAreValid(currentState.nodes, currentState.nodeErrors, (nodeId) =>
+              set({ selectedNodeId: nodeId })
+            );
 
             // Convert flow to graph
             const graph = state.toFlowGraph();


### PR DESCRIPTION
Partial fix for #238, plus the UX gap that made it undiagnosable.

## Stale validation errors block saving forever

`nodeErrors` is keyed by node ID, and **nothing pruned it when a node was removed** — not `removeNode`, not `onNodesChange` (which is what pressing Delete on the canvas goes through). The `clearNodeErrors` action that would have done it has no callers anywhere in the codebase; it is dead code.

So deleting an invalid node left its errors behind permanently. `useNodeErrors` then reports a non-zero `errorCount` that no visible node accounts for, and nothing the user does can clear it, because the node is gone.

Both removal paths now prune. `pruneNodeErrors` returns the same `Map` instance when nothing changed, so node drags do not churn the map and re-render every subscriber.

## The message was unactionable

"Fix the highlighted nodes before saving" is no help when the offending node is outside the viewport. In the flow originally attached to #238 the two invalid nodes sat at **x=3000** while everything else was under **x=1185** — they *were* highlighted, just far off-screen, which is exactly why the reporter saw a save failure and no red anywhere.

The message now names the offending nodes, selects the first one, and mentions "fit view". Both save paths share one helper rather than duplicating the check.

## Scope — what this does not fix

I could not reproduce the reporter's **second** report from the file they attached. That flow is a `numeric_state` trigger plus a `climate.set_temperature` action; loaded through `fromFlowGraph` and run through `validateAllNodes` it produces **zero** errors, and both save paths call `validateAllNodes()` before checking, so stale entries cannot survive into the save guard itself. Their second failure therefore has some other cause that the attachment does not capture.

What this PR does fix is real and verified: the stale-error class, and the message that made the first case impossible to act on. I have asked the reporter for the follow-up detail needed to chase the rest.

## Verification

- 4 new store tests; the two covering the stale-error class fail without the fix.
- Gate: typecheck clean, **317 tests pass**, lint at the pre-existing 4 warnings, format clean.

Refs #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018th9xwV2JcutmxtA1g4ekH