### PR TITLE
feat: add device and label trigger targets

### DIFF
--- a/packages/shared/src/schemas/ha-schemas.ts
+++ b/packages/shared/src/schemas/ha-schemas.ts
@@ -86,7 +86,13 @@ export const HATriggerSchema = z
     alias: z.string().optional(),
     platform: z.string().optional(),
     trigger: z.string().optional(),
-    target: z.looseObject({ entity_id: z.union([z.string(), z.array(z.string())]) }).optional(),
+    target: z
+      .union([
+        z.looseObject({ entity_id: z.union([z.string(), z.array(z.string())]) }),
+        z.looseObject({ device_id: z.union([z.string(), z.array(z.string())]) }),
+        z.looseObject({ label_id: z.union([z.string(), z.array(z.string())]) }),
+      ])
+      .optional(),
     options: z.looseObject({}).optional(),
     entity_id: z.union([z.string(), z.array(z.string())]).optional(),
     // Home Assistant supports both string, array, and null for from/to fields


### PR DESCRIPTION
# Change
The trigger.target attribute now supports setting device_id or label_id for selecting a target, I have updated the ha-schemas to support this. 

# Breaking Changes
This has no breaking changes, existing automations that pass `target.entity_id` are still valid but now you can additonally pass:
`target.device_id` and `target.label_id`

# Testing Checklist
[x] ran `yarn typecheck`
[x] ran `yarn test`
[x] ran `yarn check`
[x] ran `yarn format`

# Manual Testing: 
Import in `main` and branch version, will not work in `main` but will work in branch.

## Device ID Test:
```yaml
alias: Washing Machine Automation
description: ''
triggers:
  - trigger: power.crossed_threshold
    target:
      device_id: ac841705789afd9e919f31ac5007629d
    options:
      behavior: each
      threshold:
        type: above
        value:
          active_choice: number
          number: 100
          unit_of_measurement: W
conditions: []
actions:
  - service: notify.mobile_app
    data:
      message: "washing done"
mode: single
```

## Label ID test
```yaml
alias: Washing Machine Automation
description: ''
triggers:
  - trigger: power.crossed_threshold
    target:
      label_id: washers
    options:
      behavior: each
      threshold:
        type: above
        value:
          active_choice: number
          number: 100
          unit_of_measurement: W
conditions: []
actions:
  - service: notify.mobile_app
    data:
      message: "washing done"
mode: single
```
